### PR TITLE
fix: make InputTags clickable area match visual boundaries

### DIFF
--- a/src/InputTags/TagInput/component.tsx
+++ b/src/InputTags/TagInput/component.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 
 type Props = {
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -6,14 +6,19 @@ type Props = {
   onBlur: () => void;
 };
 
-export const TagInput: React.FC<Props> = ({ onKeyDown, onFocus, onBlur }) => {
-  return (
-    <input
-      type="text"
-      className="flex-grow border-0 mb-1 outline-none"
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onKeyDown={onKeyDown}
-    />
-  );
-};
+export const TagInput = React.forwardRef<HTMLInputElement, Props>(
+  ({ onKeyDown, onFocus, onBlur }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type="text"
+        className="flex-grow border-0 mb-1 outline-none"
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+      />
+    );
+  }
+);
+
+TagInput.displayName = "TagInput";

--- a/src/InputTags/component.test.tsx
+++ b/src/InputTags/component.test.tsx
@@ -145,3 +145,48 @@ test("フォーカス時にアクティブクラスが適用される", async ()
   expect(list).toHaveClass("border-base-content/20");
   expect(list).not.toHaveClass("border-base-content");
 });
+
+test("フィールドセットをクリックすると入力フィールドにフォーカスが当たる", async () => {
+  const onChange = mock();
+
+  const { getByRole } = render(
+    <InputTags tags={initialTags} onChange={onChange} />,
+  );
+
+  const fieldset = getByRole("group");
+  const input = getByRole("textbox");
+
+  const user = userEvent.setup();
+
+  // フィールドセットの余白部分をクリック
+  await user.click(fieldset);
+
+  // 入力フィールドがフォーカスされていることを確認
+  expect(document.activeElement).toBe(input);
+});
+
+test("タグやボタンをクリックしても入力フィールドにフォーカスが移動しない", async () => {
+  const onChange = mock();
+
+  const { getAllByRole, getByRole } = render(
+    <InputTags tags={initialTags} onChange={onChange} />,
+  );
+
+  const tagElements = getAllByRole("listitem");
+  const removeButtons = getAllByRole("button", { name: "remove tag" });
+  const input = getByRole("textbox");
+
+  const user = userEvent.setup();
+
+  // タグをクリック
+  await user.click(tagElements[0]);
+  
+  // 入力フィールドにフォーカスが移動していないことを確認
+  expect(document.activeElement).not.toBe(input);
+
+  // 削除ボタンをクリック
+  await user.click(removeButtons[0]);
+  
+  // 入力フィールドにフォーカスが移動していないことを確認
+  expect(document.activeElement).not.toBe(input);
+});

--- a/src/InputTags/component.tsx
+++ b/src/InputTags/component.tsx
@@ -40,6 +40,7 @@ export function handleTagKeyDown(
 
 export const InputTags: React.FC<Props> = ({ tags, onChange }) => {
   const [active, setActive] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   function onRemove(index: number) {
     const newTags = [...tags];
@@ -51,15 +52,31 @@ export const InputTags: React.FC<Props> = ({ tags, onChange }) => {
     handleTagKeyDown(e, tags, onChange);
   }
 
+  function handleFieldsetClick(e: React.MouseEvent<HTMLFieldSetElement>) {
+    // フィールドセット内のクリックでinputにフォーカスを当てる
+    // ただし、タグやボタンをクリックした場合は除外
+    const target = e.target as HTMLElement;
+    if (
+      target.tagName !== 'INPUT' &&
+      !target.closest('li') &&
+      !target.closest('button')
+    ) {
+      inputRef.current?.focus();
+    }
+  }
+
   return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: クリックはフォーカスを移動するだけなのでキーボードイベントは不要
     <fieldset
       className={clsx(
-        "flex flex-wrap border rounded leading-tight pt-3 pb-2 px-4 transition-all",
+        "flex flex-wrap border rounded leading-tight pt-3 pb-2 px-4 transition-all cursor-text",
         active ? "border-base-content" : "border-base-content/20",
       )}
+      onClick={handleFieldsetClick}
     >
       <TagList tags={tags} onRemove={onRemove} />
       <TagInput
+        ref={inputRef}
         onFocus={() => setActive(true)}
         onBlur={() => setActive(false)}
         onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary
- InputTagsコンポーネントのクリック可能領域を見た目の表示領域と一致させました
- フィールドセット全体をクリックすると入力フィールドにフォーカスが当たるようになりました
- タグや削除ボタンのクリックは適切に処理され、入力フィールドへのフォーカス移動は発生しません

## Changes
- fieldsetにクリックハンドラーを追加し、クリック時に入力フィールドにフォーカスを当てるように修正
- TagInputコンポーネントをforwardRefに変更してrefをサポート
- cursor-textスタイルを追加してクリック可能であることを視覚的に表示
- タグや削除ボタンのクリックを除外する処理を追加
- 新しい動作を検証するテストを追加

## Test plan
- [x] 既存のすべてのテストが通過することを確認
- [x] フィールドセットの余白部分をクリックすると入力フィールドにフォーカスが当たることを確認
- [x] タグをクリックしても入力フィールドにフォーカスが移動しないことを確認
- [x] 削除ボタンが正常に動作することを確認
- [x] TypeScriptの型チェックが通過することを確認
- [x] Lintエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)