### PR TITLE
ci: add workflow to update bun.lock for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -1,0 +1,45 @@
+name: Update bun.lock for Dependabot
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Update bun.lock
+        run: bun install
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet bun.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bun.lock
+          git commit -m "chore: update bun.lock"
+          git push


### PR DESCRIPTION
## Summary
- Add workflow to automatically update bun.lock when Dependabot creates a PR
- Fixes CI failures caused by Dependabot not understanding Bun's lockfile format

## Problem
Dependabot updates `package.json` but doesn't regenerate `bun.lock`, causing `bun install --frozen-lockfile` to fail in CI.

## Solution
New workflow `.github/workflows/dependabot-bun-lock.yml` that:
1. Triggers on PRs that modify `package.json`
2. Only runs for Dependabot PRs
3. Runs `bun install` to regenerate the lockfile
4. Commits and pushes the updated `bun.lock`

## Test plan
- [ ] Merge this PR
- [ ] Re-run CI on `dependabot/npm_and_yarn/types-58b457a1a9` branch
- [ ] Verify lockfile is updated and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)