### PR TITLE
fix: useStorage の hydration flash を lazy init で解消する

### DIFF
--- a/client/src/useStorage.flash.test.ts
+++ b/client/src/useStorage.flash.test.ts
@@ -1,0 +1,93 @@
+/**
+ * hydration flash (初期値 → storage 値のちらつき) が発生しないことを検証する
+ * リグレッションテスト。
+ *
+ * 旧実装では useState(def) → useEffect で setState の 2 段階レンダリングで
+ * ちらつきが起きていた。lazy init により初回レンダリングから storage の値が
+ * 同期的に反映されることを保証する。
+ */
+
+import { describe, expect, test } from "bun:test";
+import { render, renderHook } from "@testing-library/react";
+import React from "react";
+import { genUseStorage } from "./useStorage";
+
+class MockStorage implements Storage {
+  store: Map<string, string> = new Map();
+  getItem(key: string) {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value);
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  clear() {
+    this.store.clear();
+  }
+  key(_index: number) {
+    return null;
+  }
+  get length() {
+    return this.store.size;
+  }
+}
+
+describe("hydration flash が発生しないこと", () => {
+  test("[hook] storage に値がある場合、初回レンダリングから storage 値が返る", () => {
+    const storage = new MockStorage();
+    storage.setItem("templates", JSON.stringify(["saved-template"]));
+
+    const renders: string[][] = [];
+    renderHook(() => {
+      const [value] = genUseStorage<string[]>(storage, "templates", []);
+      renders.push([...value]);
+      return value;
+    });
+
+    // すべてのレンダリングで storage 値が返る (def が一度も見えない)
+    for (const r of renders) {
+      expect(r).toEqual(["saved-template"]);
+    }
+  });
+
+  test("[DOM] 初回 DOM に storage 値がそのまま描画される", () => {
+    const storage = new MockStorage();
+    storage.setItem("templates", JSON.stringify(["A", "B", "C"]));
+
+    const snapshots: string[] = [];
+
+    const Screen: React.FC = () => {
+      const [items] = genUseStorage<string[]>(storage, "templates", []);
+      snapshots.push(items.join(","));
+      return React.createElement(
+        "ul",
+        null,
+        items.map((x) => React.createElement("li", { key: x }, x)),
+      );
+    };
+
+    const { container } = render(React.createElement(Screen));
+
+    // 初回レンダリングから正しい値
+    expect(snapshots[0]).toBe("A,B,C");
+    expect(container.querySelectorAll("li").length).toBe(3);
+  });
+
+  test("[hook] storage が空の場合は def が返る (フラッシュ無し)", () => {
+    const storage = new MockStorage();
+
+    const renders: string[][] = [];
+    renderHook(() => {
+      const [value] = genUseStorage<string[]>(storage, "templates", []);
+      renders.push([...value]);
+      return value;
+    });
+
+    // 全てのレンダリングで def ([])
+    for (const r of renders) {
+      expect(r).toEqual([]);
+    }
+  });
+});

--- a/client/src/useStorage.ts
+++ b/client/src/useStorage.ts
@@ -1,28 +1,41 @@
 import { type Dispatch, useCallback, useEffect, useState } from "react";
 
+const readStorage = <T>(storage: Storage, key: string): T | undefined => {
+  const raw = storage.getItem(key);
+  if (raw == null) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed) {
+      storage.removeItem(key);
+      return undefined;
+    }
+    return parsed as T;
+  } catch (_e) {
+    // 無効なJSONの場合は、ストレージから削除
+    storage.removeItem(key);
+    return undefined;
+  }
+};
+
 export const genUseStorage = <T>(
   storage: Storage,
   key: string,
   def: T,
 ): [T, Dispatch<T>, () => void] => {
-  const [state, setState] = useState<T>(def);
+  // lazy init で初回レンダリングから storage の値を同期的に反映し、
+  // hydration flash (初期値 → storage 値のちらつき) を防ぐ。
+  const [state, setState] = useState<T>(
+    () => readStorage<T>(storage, key) ?? def,
+  );
 
+  // key / storage が変わった時は読み直す。
+  // def は呼び出し側で毎レンダー新しい参照になる可能性があるため依存から除外
+  // (依存に含めると空配列リテラル等で無限ループになる)。
+  // storage に値がない場合は前回値を保持する (旧実装と同挙動)。
   useEffect(() => {
-    const loaded = storage.getItem(key);
-    if (loaded == null) return;
-
-    try {
-      const parsed = JSON.parse(loaded);
-      if (!parsed) {
-        storage.removeItem(key);
-        return;
-      }
-      setState(parsed);
-    } catch (_e) {
-      // 無効なJSONの場合は、セッションストレージから削除
-      storage.removeItem(key);
-      return;
-    }
+    const value = readStorage<T>(storage, key);
+    if (value !== undefined) setState(value);
   }, [storage, key]);
 
   const setStorage = useCallback(


### PR DESCRIPTION
## Summary

- `useStorage` / `useSession` で storage の値が描画される前に初期値 `def` が一瞬見える hydration flash を解消
- `useState` の lazy init で初回レンダリングから storage 値を同期的に反映
- `def` は呼び出し側で毎レンダー新しい参照になる可能性があるため `useEffect` 依存配列から除外 (無限ループ回避)

## 背景

閉じた PR #60 と同じ問題に対する最小修正版。`#60` は `isHydrated` フラグ + `return null` で SSR 前提の hydration 遅延を入れていたが、本プロジェクトは CSR only のため不要な複雑化だった。

## 変更内容

- `client/src/useStorage.ts`: lazy init 化、`readStorage` ヘルパー抽出
- `client/src/useStorage.flash.test.ts`: リグレッションテスト追加 (hook 単位 / DOM 単位)

## Test plan

- [x] `bun run check:type` pass
- [x] `bun run check:lint` pass
- [x] `bun run check:test` — 148 pass / 0 fail (新規テスト 3 件含む)
- [ ] CI で e2e / VRT を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)