### PR TITLE
refactor(db): split DB_APP_NAME into DB_USER + DB_NAME and align defaults with stream_tag_inventory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ BUN_PUBLIC_APP_BASE_URL=http://localhost:3000
 # Database (既存)
 PGHOST=localhost
 PGPORT=5432
-DB_APP_NAME=twitch_tag_inventory
-DB_PASSWORD=twitch_tag_inventory
+DB_USER=stream_tag_inventory
+DB_NAME=stream_tag_inventory
+DB_PASSWORD=stream_tag_inventory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,21 @@ Cloud Run **gen2 実行環境は合計 512Mi 以上の memory** が必須 (CPU a
 `PORT` は **Cloud Run の予約環境変数** で、`containerPort` から自動注入される。`cloudrun.yaml` の `env` に `PORT` を追加してはいけない (起動失敗の原因)。
 server 側は `process.env.PORT ?? 3000` で受け取るため、開発時は環境変数で上書き可能だが、本番 yaml では設定不要。
 
+### DB 接続用の環境変数
+
+server (`server/src/infra/db/index.ts`) / migration (`bin/migrate.sh`) は以下の env で接続情報を受け取る:
+
+- `PGHOST` / `PGPORT`: libpq 標準。cloudflared サイドカー経由で `localhost:5432` を参照
+- `DB_USER`: DB ロール名 (現状 service / migration 共に `stream_tag_inventory`)
+- `DB_NAME`: データベース名 (同上)
+- `DB_PASSWORD`: 下記のとおり owner / app user で secret を切り替える
+
+`DB_USER` と `DB_NAME` を分離しているのは、将来 app user を owner と分ける際に user 名だけ差し替えられるようにするため。現状は同値でも env は別々に供給する。
+
 ### DB パスワードの使い分け
 
-- **migration job**: `stream-tag-inventory-db-password` (owner user — DDL 権限が必要)
-- **service**: `stream-tag-inventory-db-app-password` (app user — DML のみ)
+- **migration job** (`cloudrun-job.yaml`): `stream-tag-inventory-db-password` (owner user — DDL 権限が必要)
+- **service** (`cloudrun.yaml`): `stream-tag-inventory-db-app-password` (app user — DML のみ)
 
 混同すると migration が権限エラーで失敗するか、service に不要な DDL 権限が付与される。`-app-` サフィックスの有無で区別する。
 

--- a/bin/migrate.sh
+++ b/bin/migrate.sh
@@ -2,9 +2,9 @@
 set -eu
 export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
-export PGUSER="$DB_APP_NAME"
+export PGUSER="$DB_USER"
 export PGPASSWORD="$DB_PASSWORD"
-export PGDATABASE="$DB_APP_NAME"
+export PGDATABASE="$DB_NAME"
 
 # Wait for DB (cloudflared sidecar in Cloud Run, or direct in docker-compose)
 for i in $(seq 1 30); do

--- a/cloudrun-job.yaml
+++ b/cloudrun-job.yaml
@@ -12,7 +12,9 @@ spec:
           containers:
             - image: IMAGE_PLACEHOLDER
               env:
-                - name: DB_APP_NAME
+                - name: DB_USER
+                  value: stream_tag_inventory
+                - name: DB_NAME
                   value: stream_tag_inventory
                 # NOTE: migration job は owner pw (DDL 必要)。-app- サフィックス付きの app user pw は使わない
                 - name: DB_PASSWORD

--- a/cloudrun.yaml
+++ b/cloudrun.yaml
@@ -23,7 +23,9 @@ spec:
               memory: "256Mi"
           # NOTE: PORT env var は Cloud Run が containerPort から自動注入するため設定禁止 (予約環境変数)
           env:
-            - name: DB_APP_NAME
+            - name: DB_USER
+              value: stream_tag_inventory
+            - name: DB_NAME
               value: stream_tag_inventory
             # NOTE: service は app user pw (DML のみ)。owner pw (stream-tag-inventory-db-password) は migration job 側で使う
             - name: DB_PASSWORD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,9 @@ services:
       context: .
       dockerfile: Dockerfile.migration
     environment:
-      - DB_APP_NAME=twitch_tag_inventory
-      - DB_PASSWORD=twitch_tag_inventory
+      - DB_USER=stream_tag_inventory
+      - DB_NAME=stream_tag_inventory
+      - DB_PASSWORD=stream_tag_inventory
       - PGHOST=postgres
     depends_on:
       postgres:
@@ -45,11 +46,11 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: twitch_tag_inventory
-      POSTGRES_PASSWORD: twitch_tag_inventory
-      POSTGRES_DB: twitch_tag_inventory
+      POSTGRES_USER: stream_tag_inventory
+      POSTGRES_PASSWORD: stream_tag_inventory
+      POSTGRES_DB: stream_tag_inventory
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U twitch_tag_inventory"]
+      test: ["CMD-SHELL", "pg_isready -U stream_tag_inventory"]
       interval: 2s
       timeout: 5s
       retries: 10

--- a/server/src/infra/db/index.ts
+++ b/server/src/infra/db/index.ts
@@ -18,9 +18,9 @@ export async function initDatabase(logger: ILogger): Promise<PgDatabase> {
 
   const host = process.env.PGHOST ?? "localhost";
   const port = Number(process.env.PGPORT ?? 5432);
-  const user = process.env.DB_APP_NAME ?? "twitch_tag_inventory";
-  const password = process.env.DB_PASSWORD ?? "twitch_tag_inventory";
-  const database = process.env.DB_APP_NAME ?? "twitch_tag_inventory";
+  const user = process.env.DB_USER ?? "stream_tag_inventory";
+  const password = process.env.DB_PASSWORD ?? "stream_tag_inventory";
+  const database = process.env.DB_NAME ?? "stream_tag_inventory";
 
   log.info(`Connecting to PostgreSQL at ${host}:${port}/${database}...`);
   db = new PgDatabase({ host, port, user, password, database });

--- a/server/test/helpers/postgres.ts
+++ b/server/test/helpers/postgres.ts
@@ -5,9 +5,9 @@ import { join } from "node:path";
 import EmbeddedPostgres from "embedded-postgres";
 import type pg from "pg";
 
-const DEFAULT_USER = "twitch_tag_inventory";
-const DEFAULT_PASSWORD = "twitch_tag_inventory";
-const DEFAULT_DATABASE = "twitch_tag_inventory";
+const DEFAULT_USER = "stream_tag_inventory";
+const DEFAULT_PASSWORD = "stream_tag_inventory";
+const DEFAULT_DATABASE = "stream_tag_inventory";
 
 /**
  * Find a free TCP port by binding to port 0 and releasing.


### PR DESCRIPTION
## Summary

DB 接続に使う環境変数から `DB_APP_NAME` を廃止し、`DB_USER` (ロール名) と `DB_NAME` (データベース名) に分離する。あわせてデフォルト値を旧プロジェクト名由来の `twitch_tag_inventory` からサービス名と揃えた `stream_tag_inventory` に更新する。

## なぜ分離するのか

旧実装は `DB_APP_NAME` 1 本を user / database 両方に流用していたため、**将来 app user を owner と分離したタイミングで DB 名を触らず user 名だけ差し替える、といった変更ができない** 状態だった。

今回の PR で:

- `DB_USER` — DB ロール名 (owner / app user を将来切り替え可能に)
- `DB_NAME` — データベース名 (owner 分離後も不変)
- `DB_PASSWORD` — 既存のまま (`cloudrun.yaml` = app user secret, `cloudrun-job.yaml` = owner secret の使い分けは維持)

現状は両者とも `stream_tag_inventory` で値は一致するが、env を分けたことで片側だけを変更するのが自然にできるようになる。

## 変更点

| ファイル | 変更 |
|---|---|
| `.env.example` | `DB_APP_NAME` を `DB_USER` + `DB_NAME` に分離 / 値を `stream_tag_inventory` に更新 |
| `bin/migrate.sh` | `PGUSER="$DB_USER"` / `PGDATABASE="$DB_NAME"` に対応 |
| `docker-compose.yml` | migration service の env + postgres service の `POSTGRES_USER/DB/PASSWORD` と `pg_isready -U` を `stream_tag_inventory` に更新 |
| `server/src/infra/db/index.ts` | `initDatabase` が `DB_USER` / `DB_NAME` / `DB_PASSWORD` を個別に読むよう変更、fallback も `stream_tag_inventory` に |
| `server/test/helpers/postgres.ts` | `embedded-postgres` の default user / password / database を `stream_tag_inventory` に更新 |
| `cloudrun.yaml` / `cloudrun-job.yaml` | `DB_APP_NAME` の env entry を `DB_USER` + `DB_NAME` の 2 つに分割 |
| `CLAUDE.md` | **「DB 接続用の環境変数」セクションを新設**。各 env の役割と「なぜ `DB_USER` / `DB_NAME` を分けるか」を明文化。既存「DB パスワードの使い分け」にも `cloudrun-job.yaml` / `cloudrun.yaml` のファイル名注記を追加 |

## 互換性

**breaking change**。`.env` / 本番環境の `DB_APP_NAME` 参照箇所をすべて置換する必要がある:

- ローカル開発: `.env` を `.env.example` に合わせて `DB_USER` / `DB_NAME` を定義し、既存 DB のユーザー名/データベース名が `twitch_tag_inventory` のままなら renameするか再作成する必要あり
- Cloud Run: `cloudrun.yaml` / `cloudrun-job.yaml` を同時適用 (env 定義変更と DB 名変更は coupled)

## Test plan

- [x] `bun run check:type` — pass
- [x] `bun run check:lint` — pass (241 files)
- [x] `bun run check:arch` — pass (105 modules, 355 deps, 違反なし)
- [x] `bun run check:test` — server 62 pass / client 148 pass / 0 fail
- [x] `bun run check:e2e` — chromium 17 passed (firefox/webkit は host system library 不足によるサンドボックス制約で実行不可。CI 環境では実行される想定)
- [ ] ローカルで `docker-compose up` → migration job が新しい env で正常に流れることを確認
- [ ] Cloud Run staging で migration job + service デプロイ後、接続ログに `stream_tag_inventory` として接続されていることを確認