### PR TITLE
feat(deploy): service を app user (DML のみ) に切り替える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,21 +197,29 @@ server 側は `process.env.PORT ?? 3000` で受け取るため、開発時は環
 server (`server/src/infra/db/index.ts`) / migration (`bin/migrate.sh`) は以下の env で接続情報を受け取る:
 
 - `PGHOST` / `PGPORT`: libpq 標準。cloudflared サイドカー経由で `localhost:5432` を参照
-- `DB_USER`: DB ロール名 (現状 service / migration 共に `stream_tag_inventory`)
-- `DB_NAME`: データベース名 (同上)
+- `DB_USER`: DB ロール名 (service = `stream_tag_inventory_app`, migration = `stream_tag_inventory`)
+- `DB_NAME`: データベース名 (`stream_tag_inventory`)
 - `DB_PASSWORD`: 下記のとおり owner / app user で secret を切り替える
-
-`DB_USER` と `DB_NAME` を分離しているのは、将来 app user を owner と分ける際に user 名だけ差し替えられるようにするため。現状は同値でも env は別々に供給する。
 
 ### DB パスワードの使い分け
 
-**現状**: `cloudrun.yaml` (service) / `cloudrun-job.yaml` (migration) の **両方が owner password** (`stream-tag-inventory-db-password`) を使っている。production DB に app user (DML 専用) が作成されていないため。`stream-tag-inventory-db-app-password` secret は値こそあるが対応する user が存在しないので失敗する (deploy 時にこれで躓いた経緯あり)。
+least privilege の原則に従い owner と app user を分離している:
 
-**本来の意図 (TODO)**:
-- migration job: `stream-tag-inventory-db-password` (owner — DDL 必要)
-- service: `stream-tag-inventory-db-app-password` (app — DML のみ)
+- **migration job** (`cloudrun-job.yaml`): `stream_tag_inventory` (owner, DDL 可) + `stream-tag-inventory-db-password`
+- **service** (`cloudrun.yaml`): `stream_tag_inventory_app` (DML のみ) + `stream-tag-inventory-db-app-password`
 
-app user を DB 側に `CREATE USER + GRANT` で用意したら、service の cloudrun.yaml を app 側に切り替える。`-app-` サフィックスの有無で secret を区別する命名規約は維持する。
+DB 側の user 定義 / GRANT / パスワード set は本 repo では管理しておらず、**infra repo (`yuniruyuni.net`) の `nixos/services/postgresql.nix`** で宣言的に扱われる。`postgresql-app-credentials` systemd oneshot が activation 毎に両 user のパスワードを age secret から `ALTER USER` で反映し、app user には `SELECT/INSERT/UPDATE/DELETE ON ALL TABLES` + `ALTER DEFAULT PRIVILEGES` (将来の table/sequence 自動追従) を付与する。
+
+**パスワード値の同期は手動運用**: age secret (NixOS 側の source of truth) と GCP Secret Manager (`stream-tag-inventory-db-password` / `stream-tag-inventory-db-app-password`) の値は自動同期されない。片方を rotate したらもう片方にも同値を put し直す必要がある。ズレると Cloud Run 起動時の `SELECT 1` で `FATAL: password authentication failed` になる。
+
+### DB パスワード rotate 時の手順
+
+age secret を rekey した場合の典型フロー:
+
+1. infra repo 側で age secret を更新 → NixOS activation で `ALTER USER` 走行 (DB 側の値が変わる)
+2. 同じ値を GCP Secret Manager に新 version として put: `printf '%s' '<new-pw>' | gcloud secrets versions add stream-tag-inventory-db-app-password --data-file=-` (末尾改行込みで揃えるか、末尾改行なしで put するかは既存値の shape に合わせる — 後述)
+3. Cloud Run を re-deploy (service は起動時に最新 version を fetch)
+4. Cloud Run logs で `Database ready` が出ることを確認
 
 ### DB_PASSWORD の末尾改行に注意
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ Client ID は以下 3 箇所に反映:
 Cloud Run deploy に必要な Secret を Google Cloud Secret Manager に作成する。すべて **末尾改行を含めずに** 作成すること (code 側で trim する防御策は入っているが混乱の元)。
 
 ```bash
-# DB パスワード (owner 権限、DDL 可)
+# DB パスワード (owner 権限、DDL 可。migration job が使用)
 printf "%s" "<strong-random-32chars>" | \
   gcloud secrets create stream-tag-inventory-db-password --data-file=-
 
-# app user パスワード (現状未使用。app user を DB 側で作成後に切替予定)
+# app user パスワード (DML のみ。service が使用)
+# 値は infra repo (yuniruyuni.net) の age secret と手動で一致させる必要がある。
+# DB 側の user / GRANT / password set は NixOS 側で宣言的に管理されている。
 printf "%s" "<another-random-32chars>" | \
   gcloud secrets create stream-tag-inventory-db-app-password --data-file=-
 

--- a/cloudrun.yaml
+++ b/cloudrun.yaml
@@ -23,20 +23,20 @@ spec:
               memory: "256Mi"
           # NOTE: PORT env var は Cloud Run が containerPort から自動注入するため設定禁止 (予約環境変数)
           env:
+            # service は app user (DML のみ) を使う。owner (DDL 可) は migration job 専用。
+            # app user は infra (yuniruyuni.net repo の nixos/services/postgresql.nix) で
+            # 宣言的に CREATE + GRANT されており、パスワードは age secret を source of
+            # truth として activation 毎に ALTER USER で set される。GCP Secret Manager 側の
+            # stream-tag-inventory-db-app-password の値は age secret と手動で一致させる運用。
             - name: DB_USER
-              value: stream_tag_inventory
+              value: stream_tag_inventory_app
             - name: DB_NAME
               value: stream_tag_inventory
-            # 当面は migration と同じ owner pw を使う。本来は app user (DML のみ) を
-            # DB 側に作って app password と紐付けるべきだが、現状 production には
-            # stream_tag_inventory user (= owner) のみ存在し、app user が未作成。
-            # owner pw で起動時 SELECT 1 が通る形にしておき、app user 分離は別 PR
-            # で対応する (DB に CREATE USER + GRANT + secret 紐付けが必要)。
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: latest
-                  name: stream-tag-inventory-db-password
+                  name: stream-tag-inventory-db-app-password
             # Twitch OIDC 用。client_id は OAuth の仕様上公開値 (client/src/constant.ts にも平文)、
             # かつ static/index.js に焼き込まれてブラウザから可視なので平文 value で扱う。
             # 本番用に別 Twitch app を作る場合も値自体は公開情報のため repo に commit してよい。


### PR DESCRIPTION
## Summary

- Cloud Run service の DB 接続を owner (`stream_tag_inventory`) から app user (`stream_tag_inventory_app`) に切り替え、`stream-tag-inventory-db-app-password` secret を参照するよう変更
- migration job (`cloudrun-job.yaml`) は owner のまま (DDL 権限が必要なため無変更)
- DB 側の app user / GRANT / パスワード set は infra repo (`yuniruyuni.net`) の `nixos/services/postgresql.nix` で既に宣言的に管理済みのため、本 repo では `cloudrun.yaml` の参照先だけを差し替える

## 背景

CLAUDE.md に TODO として残っていた least privilege 化。過去は「app user が未作成」の記述だったが、infra repo 側で既に `stream_tag_inventory_app` の CREATE / GRANT / password set が行われているため、app 側の cutover のみで完了する。

## 変更点

- `cloudrun.yaml`: `DB_USER` = `stream_tag_inventory_app`、`DB_PASSWORD` secret = `stream-tag-inventory-db-app-password` に差し替え、注釈コメントを現状化
- `CLAUDE.md`: 「DB パスワードの使い分け」を分離完了前提に書き換え。age secret ↔ GCP secret の手動同期が必要な運用を明記、rotate 手順を追記
- `README.md`: app password 用途のコメントを現状化

## リスクと論点

- **GCP Secret Manager の `stream-tag-inventory-db-app-password` の値が NixOS 側の `db-password-stream_tag_inventory_app.age` と一致している必要あり**。ズレていると deploy 後の起動時 `SELECT 1` で `FATAL: password authentication failed` になる
- 一致しない場合の対応: GCP secret に同じ値を再投入して re-deploy (rollback は owner secret への revert)

## Test plan

- [ ] Merge 後 deploy.yml が成功して Cloud Run の新リビジョンが active になる
- [ ] Cloud Run logs で `Database ready` が出る (起動時 `SELECT 1` 通過)
- [ ] 本番 UI からログイン → テンプレート作成/更新 → サーバ sync (tRPC `template.sync`) が成功する (INSERT/UPDATE 権限確認)
- [ ] 既存テンプレートが画面に出る (SELECT 権限確認)
- [ ] 何らかの理由で auth fail した場合は `cloudrun.yaml` の `DB_USER` / `DB_PASSWORD` secret を revert して再 deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)