### PR TITLE
docs(adr): PR #85 + #86 の設計判断を ADR 0008 / 0009 として記録

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ server (`server/src/infra/db/index.ts`) / migration (`bin/migrate.sh`) は以下
 
 ### DB パスワードの使い分け
 
-least privilege の原則に従い owner と app user を分離している:
+least privilege の原則に従い owner と app user を分離している ([ADR 0008](./docs/adr/0008-cloud-run-service-connects-as-dml-only-app-user.md)):
 
 - **migration job** (`cloudrun-job.yaml`): `stream_tag_inventory` (owner, DDL 可) + `stream-tag-inventory-db-password`
 - **service** (`cloudrun.yaml`): `stream_tag_inventory_app` (DML のみ) + `stream-tag-inventory-db-app-password`
@@ -236,7 +236,7 @@ DB アクセスは Cloudflare Tunnel 経由で `db.yuniruyuni.net` へ接続す�
 
 ### pgschema の declarative GRANT と role 宣言
 
-table への `GRANT` と `ALTER DEFAULT PRIVILEGES` は `schema/tables/*.sql` 内に宣言することで pgschema が diff 管理する (per-table GRANT を追加・削除・変更するとそのまま migration plan に乗る)。
+table への `GRANT` と `ALTER DEFAULT PRIVILEGES` は `schema/tables/*.sql` 内に宣言することで pgschema が diff 管理する ([ADR 0009](./docs/adr/0009-declarative-per-table-grant-via-pgschema.md))。per-table GRANT を追加・削除・変更するとそのまま migration plan に乗る。
 
 **制約**: pgschema の plan phase は embedded plan DB に desired state を一度流して validation するため、参照する role が plan DB に存在しないと `role does not exist` で fail する。
 

--- a/docs/adr/0008-cloud-run-service-connects-as-dml-only-app-user.md
+++ b/docs/adr/0008-cloud-run-service-connects-as-dml-only-app-user.md
@@ -1,0 +1,105 @@
+---
+id: "0008"
+title: "Cloud Run service は DML-only の app user で DB 接続する (least privilege)"
+status: "accepted"
+date: "2026-04-23"
+supersedes: null
+superseded_by: null
+related_specres: []
+tags: ["security", "db", "cloud-run", "least-privilege"]
+---
+
+## コンテキスト
+
+[ADR 0007](./0007-stateless-jwt-bearer-no-server-session.md) 以降、本ツールの DB 操作は `template_docs` 表への per-user Y.Doc upsert / select のみに縮退した。しかし Cloud Run service と pgschema migration job は同一 secret (`stream-tag-inventory-db-password`) 経由で **両方とも owner role (`stream_tag_inventory`)** を使用しており、service が DDL 権限を持ったまま稼働している状態だった。
+
+infra repo (`yuniruyuni.net`) の NixOS 構成では既に app user (`stream_tag_inventory_app`) が宣言的に作成され、GCP Secret Manager にも対応する secret (`stream-tag-inventory-db-app-password`) が存在していた。にも関わらず app user への切替が行われていなかった経緯として:
+
+1. 初期セットアップ時点では DB 側に app user が未作成だった (NixOS 構成に追記する前の時期)
+2. その状態で deploy すると owner pw でしか起動できず、app secret を指すと `password authentication failed` で service が落ちていた
+3. NixOS 側で app user を作成した後も、app repo 側の `cloudrun.yaml` は owner を向いたままになっていた (CLAUDE.md に TODO として記録のみ)
+
+ADR 0007 で schema が最小化され、**service が必要とする操作は `SELECT / INSERT / UPDATE` のみ** (DELETE も当面不要、将来テンプレート完全削除時のため GRANT しておく) という状態が明確になったため、least privilege を実現する条件が揃った。
+
+## 検討した選択肢
+
+### 案A: owner を service でも使い続ける (却下)
+
+- **メリット**
+  - secret が 1 つで済む、cloudrun.yaml の変更不要
+- **デメリット**
+  - service プロセスが DDL 権限を持ったまま動く。万一 app 側の tRPC handler に SQL injection / raw query 漏洩 / deserialization RCE 等が入り込むと、テーブル DROP や schema 改ざんまで到達しうる
+  - incident 時の blast radius が不必要に広い
+
+### 案B: service は app user (DML のみ) / migration job は owner (DDL 必要) に分離 (採用)
+
+- **メリット**
+  - service のプロセス権限が最小化される。万一侵害されても `template_docs` 行の read / write / delete までで DDL は届かない
+  - migration job と service が異なる secret を使うことで「どの経路でどの権限が発動しているか」が env から即座に読める (`cloudrun.yaml` vs `cloudrun-job.yaml`)
+  - ADR 0007 でロールの責務が明確になった副産物として、ほぼゼロコストで実現できる
+- **デメリット**
+  - 管理する secret が 2 つになる
+  - secret rotate 時に両方を同期させる手順が要る (CLAUDE.md「DB パスワード rotate 時の手順」に明記)
+  - 新しい table を追加した際に app user へ GRANT する手順を忘れると permission denied になる (→ [ADR 0009](./0009-declarative-per-table-grant-via-pgschema.md) で declarative 化して解消)
+
+### 案C: service 用に read-only user と read-write user をさらに分離 (却下)
+
+- **メリット**
+  - GET 系経路の権限がさらに絞れる
+- **デメリット**
+  - 本ツールの全 tRPC mutation / query が同じ pool (PgDatabase) を共有している構造なので、読み書きを別 user に分けるには infra の pool 分割が必要
+  - 単一ユーザー向けツールで取引量が少なく、コストに対するリターンが薄い
+
+## 決定
+
+**案B を採用する**。`cloudrun.yaml` の service container は `stream_tag_inventory_app` + `stream-tag-inventory-db-app-password` で接続し、`cloudrun-job.yaml` の migration job は引き続き `stream_tag_inventory` + `stream-tag-inventory-db-password` で接続する。
+
+DB role 自体の CREATE USER / ALTER USER PASSWORD / CONNECT / SCHEMA USAGE は infra repo (`yuniruyuni.net/nixos/services/postgresql.nix`) が宣言的に管理する。app repo の責務は「どの secret / どの DB_USER を使うか」の指定のみ。
+
+### 分担マトリクス
+
+| 責務 | 所在 |
+|---|---|
+| owner role の存在 / password | infra repo (NixOS age secret → ALTER USER) |
+| app user role の存在 / password | 同上 |
+| GCP Secret Manager の secret 本体 | infra repo (`gcp.tf` で `google_secret_manager_secret` 宣言) |
+| Secret 値の投入 / 同期 | 手動運用 (age secret と同値を put) |
+| service が参照する secret 名 / DB_USER | **app repo (`cloudrun.yaml`)** |
+| migration job が参照する secret 名 / DB_USER | **app repo (`cloudrun-job.yaml`)** |
+| per-table GRANT | **app repo (pgschema declarative / [ADR 0009](./0009-declarative-per-table-grant-via-pgschema.md))** |
+
+## 帰結
+
+### 良い帰結
+
+- service プロセスが侵害された場合でも DDL 不可 / 他 table 作成不可 / 他 schema 参照不可に留まる
+- `cloudrun.yaml` / `cloudrun-job.yaml` 2 ファイルの対比で「どの権限を持って動いているか」が明示的にレビューできる
+- 将来 read-only API を追加する場合の拡張点が開く (さらに細分化した user を追加できる)
+
+### 悪い帰結
+
+- GCP Secret Manager 上に同期要件のある secret が 2 つ存在する。値がズレると service 起動時の `SELECT 1` で `password authentication failed` になる (`CLAUDE.md` の rotate 手順を参照)
+- infra repo と app repo で「role 名」という文字列が重複する。rename 時に両方を変える必要がある (ただし rename する動機はほぼ無い)
+
+### 影響範囲
+
+- **app repo**:
+  - `cloudrun.yaml` — `DB_USER=stream_tag_inventory_app`, `DB_PASSWORD` secretKeyRef を `stream-tag-inventory-db-app-password` に変更
+  - `cloudrun-job.yaml` — 変更なし (owner を維持)
+  - `CLAUDE.md` の「DB パスワードの使い分け」を least privilege 採用後の構成に書き換え、rotate 手順を追記
+  - `README.md` の「app user パスワード」説明を現状化
+- **infra repo (`yuniruyuni.net`)**: 本 ADR は既存の NixOS 構成を前提にしており、infra 側の変更は不要 (既に app user / secret は存在する)
+
+## インシデント / 注意点
+
+### 初回 deploy 時の permission denied
+
+本 ADR を適用した PR 直後、`templates.sync` mutation が `permission denied for table template_docs (SQLSTATE 42501)` で 500 を返した。原因は NixOS 側の `postgresql-app-credentials` oneshot が「活性化時点で存在する table に `GRANT ... ON ALL TABLES` を発行する」設計のため、`template_docs` が ADR 0007 で追加された後に oneshot が再実行されていなかったため app user へ GRANT されていなかった。
+
+暫定対処として infra ホストで `systemctl start postgresql-app-credentials.service` を実行して復旧。構造的な解消は [ADR 0009](./0009-declarative-per-table-grant-via-pgschema.md) で対応する。
+
+## 参照
+
+- ADR-0002 (Twitch トークンを DB に持たない — DB 漏洩時の blast radius を小さくする方向性を本 ADR も継承)
+- ADR-0007 (stateless JWT Bearer — schema 最小化により本 ADR の least privilege が実用的になった)
+- ADR-0009 (pgschema declarative GRANT — 本 ADR の運用課題を declarative に解消)

--- a/docs/adr/0009-declarative-per-table-grant-via-pgschema.md
+++ b/docs/adr/0009-declarative-per-table-grant-via-pgschema.md
@@ -1,0 +1,133 @@
+---
+id: "0009"
+title: "per-table GRANT を pgschema で declarative に管理し、DB role 本体は NixOS が source of truth"
+status: "accepted"
+date: "2026-04-23"
+supersedes: null
+superseded_by: null
+related_specres: []
+tags: ["db", "migration", "pgschema", "security", "infra"]
+---
+
+## コンテキスト
+
+[ADR 0008](./0008-cloud-run-service-connects-as-dml-only-app-user.md) で Cloud Run service を app user (`stream_tag_inventory_app`) に切り替えた直後、本番で `templates.sync` が `permission denied for table template_docs (SQLSTATE 42501)` で 500 を返す事故が発生した。
+
+原因分析:
+
+- infra repo (`yuniruyuni.net`) の NixOS 構成は `postgresql-app-credentials` systemd oneshot で `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stream_tag_inventory_app` を発行している
+- ただしこの `GRANT ... ON ALL TABLES` は **実行時点で存在する table にしか効かない** (PostgreSQL の仕様)
+- `template_docs` は ADR 0007 migration (2026-04-20) で新規作成されたが、以降 `nixos-rebuild switch` が走っていなかったため oneshot が再実行されず、`template_docs` 個別には GRANT が付与されていなかった
+- `ALTER DEFAULT PRIVILEGES` も同 oneshot が発行していたが、これは **設定後** に作られた table にしか適用されない (`template_docs` が先に存在していたため無効)
+
+`systemctl start postgresql-app-credentials.service` を実行して暫定復旧したが、同じ構造で「新 table 追加 → 次の NixOS activation までの間 permission denied」が永続的に発生し続けるため、根治策が必要になった。
+
+同時に、本 repo は pgschema を declarative schema migration に採用しているが、**`.pgschemaignore` で `[privileges]` / `[default_privileges]` を ignore** していたため、GRANT 系統は pgschema の対象外になっていた。これは過去の経緯として「pgschema の plan phase が内部 temp schema で desired state を validate するが、その scratch 環境に production の role が存在しないため `role does not exist` で fail する」という既知の制約を回避するための設定だった。
+
+## 検討した選択肢
+
+### 案A: 現状維持 — NixOS で `GRANT ON ALL TABLES` を撒く (却下)
+
+- **メリット**
+  - 追加の変更なし
+- **デメリット**
+  - 「新 table 追加 → NixOS activation 待ち」の競合状態が永続する
+  - app repo の CI で schema を追加しても、infra repo の activation が別手動で走らない限り権限が付かない。構造的に壊れやすい
+
+### 案B: `bin/migrate.sh` の末尾で psql 経由に GRANT を流す (却下)
+
+- **メリット**
+  - schema 変更と GRANT が同じ CI で着地する (タイミング問題が消える)
+  - `--plan-host` を外部 DB に向ける必要がなく、既存の接続情報で完結
+- **デメリット**
+  - app repo 側の bash スクリプトに role 名 (`stream_tag_inventory_app`) と GRANT の全列挙をハードコードすることになり、infra repo との drift 源が生まれる
+  - declarative 性を失う (bash のべた書きになる)
+  - 複数 table が増えるたびに script に追記する運用負荷
+
+### 案C: pgschema の `--plan-host` を本番 DB に向ける (却下)
+
+`.pgschemaignore` を外し、`--plan-host` で本番 cluster 内の別 DB (`plandb`) もしくは本番 DB 自身を plan 用に使うことで、role が plan phase でも参照可能になる。
+
+- **メリット**
+  - 仕組みとしては最小変更
+- **デメリット**
+  - **GitHub Actions の schema-plan ワークフローから本番 cluster への接続が必要** になる。plan は PR で発火するため、攻撃面が大きく広がる。`yuniruyuni.net` repo 外の PR (dependabot / 将来の contributor) から本番 DB への経路ができるのは致命的
+  - 外部 DB を立てる案 (`plandb` を本番 cluster に置かない方式) も検討したが、role を CI 環境で pre-create するための init スクリプトが別途必要になり、role 名の drift 源が再度生まれる
+
+### 案D: app repo 側で裸の `CREATE ROLE` を宣言し、pgschema の embedded plan DB にだけ role を作らせる (採用)
+
+pgschema の挙動を実地検証した結果、以下が確認できた:
+
+1. pgschema の **dump scope は `--schema` で指定した schema (= public) 配下のオブジェクトに限定**される。role は cluster-level のため dump に含まれない → 同 plan から **CREATE ROLE が target DB の diff として出力されない**
+2. embedded plan DB は呼び出しごとに fresh に spawn される。つまり一時的に role を `CREATE ROLE` で作っても target DB に伝播しない
+3. pgschema は GRANT / REVOKE / ALTER DEFAULT PRIVILEGES を declarative に diff する機能を完備している (`.pgschemaignore` で opt-out していただけ)
+
+したがって以下で完結する:
+
+- `schema/tables/000_roles.sql` に `DO $$ ... IF NOT EXISTS ... CREATE ROLE ... $$` を置く (*1)
+- 各 table の SQL 末尾に `GRANT SELECT, INSERT, UPDATE, DELETE ON <table> TO stream_tag_inventory_app;` を書く
+- `.pgschemaignore` の `[privileges]` / `[default_privileges]` セクションを削除して pgschema に管理を任せる
+- infra repo 側の `postgresql-app-credentials` からは `GRANT ON ALL TABLES` / `ALTER DEFAULT PRIVILEGES` を削除 (別作業、本 ADR の follow-up)
+
+(*1) `DO` block で冪等化する理由: `server/test/helpers/pgschema.ts` は target DB 自身を `--plan-host` に指定する (テスト高速化のため) ため、target DB (embedded-postgres) が superuser として `stream_tag_inventory` を持っている場合、裸の `CREATE ROLE` だと `role already exists` で失敗する。production migration の embedded plan DB は毎回 fresh なので裸でも動くが、テスト環境との両立のために DO block ガードを入れる。PostgreSQL は `CREATE ROLE IF NOT EXISTS` を native に sport していないため DO block は構文上必須。
+
+- **メリット**
+  - **新 table 追加 + GRANT が同じ pgschema migration でアトミックに反映される** ため、本 ADR のきっかけになった競合状態が原理的に消滅
+  - plan phase は embedded plan DB のみで完結し、本番 DB へのアクセスが不要 (CI security が保てる)
+  - DB role の生存管理は infra repo (NixOS) が source of truth のまま。app repo で宣言するのは「pgschema plan DB で validation を通すための role 名参照」だけで、password や認証方法は関与しない
+  - `.pgschemaignore` を全消去でき、pgschema の declarative 性が最大化される
+- **デメリット**
+  - role 名 (`stream_tag_inventory` / `stream_tag_inventory_app`) が app repo と infra repo の両方に出現する。ただし app repo 側は「pgschema を validate させるための宣言」に限られ、password / 認証方法は infra repo のまま。drift するリスクは role 名の rename 時のみ (頻度極小)
+  - pgschema の挙動に依存した設計であり、「dump scope が schema-local」「embedded plan DB が fresh」という前提が将来変わると破綻する。ただし pgschema 1.6.x 時点で公式ドキュメントに明記された仕様であり、本 ADR で検証済
+
+## 決定
+
+**案D を採用する**。per-table GRANT は `schema/tables/*.sql` に宣言し、pgschema の declarative diff で反映する。DB role の CREATE / ALTER / CONNECT / SCHEMA USAGE は infra repo (`yuniruyuni.net/nixos/services/postgresql.nix`) が source of truth を維持する。
+
+### 責務分担 (ADR 0008 のマトリクスを再掲)
+
+| 責務 | 所在 |
+|---|---|
+| role の存在 / password / CONNECT / SCHEMA USAGE | infra repo (NixOS) |
+| per-table GRANT | **app repo (pgschema declarative)** |
+| `ALTER DEFAULT PRIVILEGES` | app repo (declarative 時は不要になる見込み) |
+| plan DB 用の role 宣言 | app repo (`schema/tables/000_roles.sql`) |
+
+### なぜ `ALTER DEFAULT PRIVILEGES` を残さないのか
+
+案D + declarative なら「新 table を追加したら必ず同じ PR で GRANT も宣言する」運用に落ちる。`ALTER DEFAULT PRIVILEGES` はあくまで「GRANT 宣言を忘れたときの safety net」であり、declarative のレビュー / plan 段階で GRANT 漏れに気付ける以上冗長。むしろ残すと「GRANT を忘れても default で通ってしまう」ケースで漏れに気付けなくなるため、**明示 GRANT のみを正とする** 方針を取る。
+
+## 帰結
+
+### 良い帰結
+
+- 新 table + GRANT がアトミックに migration に載るため、`permission denied` 競合が発生しない
+- `.pgschemaignore` が不要になり、pgschema の管理範囲が最大化される (将来 index / view / constraint に対する GRANT も同じ仕組みで扱える)
+- plan phase は embedded plan DB のみで完結し、**CI からの本番接続が必要にならない**
+- app repo と infra repo の責務境界がより明確になる (role 管理 = infra / permission 宣言 = app)
+
+### 悪い帰結
+
+- `schema/tables/000_roles.sql` が必要になる。純粋な schema 宣言と違って「pgschema の plan DB を通すための存在」という説明的な存在になる (コメントで意図を明記済)
+- role 名の文字列が app repo にも出現し、infra repo と 2 箇所の暗黙的合意になる。rename する場合は両方の変更が必要
+- pgschema の「dump scope = schema-local」「embedded plan DB は fresh」という前提に依存する。upstream の挙動変更で破綻する可能性がある (ただし `.pgschemaignore` の existence が示すように、pgschema 公式はこれらを安定仕様として提供している)
+- 初回適用時に NixOS 側が先に発行していた `ALTER DEFAULT PRIVILEGES` が pgschema の REVOKE で撤去される diff が発生する。follow-up で infra 側の宣言を削除するまでは、NixOS activation / migration のたびに双方向 drift が往復する
+
+### 影響範囲
+
+- **app repo**:
+  - `schema/tables/000_roles.sql` 新設 (DO block で role を冪等宣言)
+  - `schema/tables/template_docs.sql` 末尾に per-table GRANT を追加
+  - `.pgschemaignore` 削除 (および `Dockerfile.migration` の COPY 行を削除)
+  - `CLAUDE.md` に「pgschema の declarative GRANT と role 宣言」節を追加
+  - `.github/workflows/schema-plan.yml` の baseline apply に `--auto-approve` を追加 (初めて main に schema があり且つ PR が schema を変える状況で顕在化したバグ)
+- **infra repo (`yuniruyuni.net`)** — follow-up として:
+  - `nixos/services/postgresql.nix` から `GRANT ... ON ALL TABLES IN SCHEMA public` / `GRANT ... ON ALL SEQUENCES IN SCHEMA public` / `ALTER DEFAULT PRIVILEGES ... TABLES` / 同 SEQUENCES を削除
+  - `CREATE USER` / `ALTER USER ... PASSWORD` / `GRANT CONNECT ON DATABASE` / `GRANT USAGE ON SCHEMA public` は残す (pgschema の dump scope 外 / cluster level の責務)
+
+## 参照
+
+- ADR-0007 (stateless JWT Bearer — schema 最小化により本 ADR の per-table GRANT コストが現実的になった)
+- ADR-0008 (Cloud Run service の least privilege 採用 — 本 ADR のきっかけになった permission denied 事故の前提)
+- `CLAUDE.md` 「pgschema の declarative GRANT と role 宣言」節 — 実装者向け運用ガイド
+- pgschema 公式: `--plan-host` / `--plan-db` フラグと `.pgschemaignore` の `[privileges]` / `[default_privileges]` セクション仕様 (1.6.x 時点)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,10 @@
 | [0003](./0003-templates-use-fractional-indexing.md) | テンプレートの並び順は fractional indexing で管理する | superseded → 0004 | 2026-04-17 |
 | [0004](./0004-local-first-sync-with-yjs.md) | テンプレートデータは Yjs による local-first 同期で管理する | accepted | 2026-04-17 |
 | [0005](./0005-session-cookie-hashed-at-rest.md) | session cookie は raw 32B トークン、DB は SHA-256 ハッシュで分離保管する | superseded → 0006 | 2026-04-19 |
-| [0006](./0006-session-token-via-bearer-header.md) | session token は Authorization: Bearer で運び client は sessionStorage に保管する | accepted | 2026-04-19 |
+| [0006](./0006-session-token-via-bearer-header.md) | session token は Authorization: Bearer で運び client は sessionStorage に保管する | superseded → 0007 | 2026-04-19 |
+| [0007](./0007-stateless-jwt-bearer-no-server-session.md) | サーバー側 session を廃止し Twitch id_token を毎回検証する Bearer 認証にする | accepted | 2026-04-19 |
+| [0008](./0008-cloud-run-service-connects-as-dml-only-app-user.md) | Cloud Run service は DML-only の app user で DB 接続する (least privilege) | accepted | 2026-04-23 |
+| [0009](./0009-declarative-per-table-grant-via-pgschema.md) | per-table GRANT を pgschema で declarative に管理し、DB role 本体は NixOS が source of truth | accepted | 2026-04-23 |
 
 ## ADR に書くこと / 書かないこと
 


### PR DESCRIPTION
## Summary

- ADR 0008: Cloud Run service を DML-only の app user で接続する設計 (PR #85)
- ADR 0009: per-table GRANT を pgschema declarative 管理、DB role 本体は NixOS 管理 (PR #86)
- ADR README と CLAUDE.md の該当節に相互リンクを追加

## 背景

PR #85 / #86 で実装した 2 つの設計判断は、将来「なぜ service は app user なのか」「なぜ plan DB は本番 DB じゃないのか」という問いに直面する可能性が高く、判断経緯を ADR として残す価値がある。特に ADR 0009 の案C (plan DB を本番接続する) を CI security 観点で却下した理由は、安易に「plan phase は production の role を参照するのが一番簡単」という罠に将来の誰か (私含む) が落ちるのを防ぐ。

## Test plan

- [ ] CI の lint / type check / test が pass (docs のみ、挙動変更なし)
- [ ] レンダリング確認: ADR README の新エントリがリンク可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)