### PR TITLE
test(client): templateIO と NotificationBanner のカバレッジ改善

### DIFF
--- a/client/src/Notification/NotificationBanner.test.tsx
+++ b/client/src/Notification/NotificationBanner.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, mock, test } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import type React from "react";
+import { useEffect, useRef } from "react";
+import { NotificationProvider, useNotification } from "./context";
+import { NotificationBanner } from "./NotificationBanner";
+import type { NotificationProps, NotificationType } from "./types";
+
+const baseProps = (
+  overrides: Partial<NotificationProps> = {},
+): NotificationProps => ({
+  id: "n1",
+  type: "info",
+  title: "Title",
+  message: "Message body",
+  autoClose: false,
+  ...overrides,
+});
+
+const renderInProvider = (notification: NotificationProps) =>
+  render(
+    <NotificationProvider>
+      <NotificationBanner notification={notification} />
+    </NotificationProvider>,
+  );
+
+describe("NotificationBanner", () => {
+  test("renders title, message, and role=alert", () => {
+    const { getByRole, getByText } = renderInProvider(
+      baseProps({ title: "Hello", message: "world" }),
+    );
+    expect(getByRole("alert")).toBeInTheDocument();
+    expect(getByText("Hello")).toBeInTheDocument();
+    expect(getByText("world")).toBeInTheDocument();
+  });
+
+  test.each<{ type: NotificationType; iconTitle: string }>([
+    { type: "success", iconTitle: "Success" },
+    { type: "error", iconTitle: "Error" },
+    { type: "warning", iconTitle: "Warning" },
+    { type: "info", iconTitle: "Information" },
+  ])("renders correct icon for type=$type", ({ type, iconTitle }) => {
+    const { getByText } = renderInProvider(baseProps({ type }));
+    expect(getByText(iconTitle)).toBeInTheDocument();
+  });
+
+  test("renders progress bar when autoClose is true", () => {
+    const { container } = renderInProvider(baseProps({ autoClose: true }));
+    expect(container.querySelector(".animate-shrink")).not.toBeNull();
+  });
+
+  test("does NOT render progress bar when autoClose is false", () => {
+    const { container } = renderInProvider(baseProps({ autoClose: false }));
+    expect(container.querySelector(".animate-shrink")).toBeNull();
+  });
+
+  test("close button triggers exit animation (adds translate-x-full class)", () => {
+    const { getByRole } = renderInProvider(baseProps({ autoClose: false }));
+    const alert = getByRole("alert");
+    expect(alert.className).not.toMatch(/translate-x-full/);
+
+    // alert 内に button は 1 つしかないため role だけで一意
+    fireEvent.click(getByRole("button"));
+
+    expect(alert.className).toMatch(/translate-x-full/);
+    expect(alert.className).toMatch(/opacity-0/);
+  });
+
+  test("close button eventually removes notification from provider state", async () => {
+    const seen: { ids: string[] } = { ids: [] };
+    const Probe: React.FC = () => {
+      const { notifications } = useNotification();
+      seen.ids = notifications.map((n) => n.id);
+      return null;
+    };
+
+    /**
+     * NotificationBanner は props の notification を描画し、removeNotification
+     * に id を渡して消す構造。Harness で useNotification.addNotification を 1 回
+     * 呼び、state 側に同じ id の notification を積んでおく。
+     * render-phase に setState するのは違反なので useEffect でマウント後に実行。
+     */
+    const Harness: React.FC = () => {
+      const { addNotification, notifications } = useNotification();
+      // 厳密に 1 回だけ add する (remove → 0 → useEffect 再発火による再 add を防ぐ)
+      const addedRef = useRef(false);
+      useEffect(() => {
+        if (addedRef.current) return;
+        addedRef.current = true;
+        addNotification({
+          type: "info",
+          title: "T",
+          message: "M",
+          autoClose: false,
+        });
+      }, [addNotification]);
+      const n = notifications[0];
+      return n ? <NotificationBanner notification={n} /> : null;
+    };
+
+    const { getByRole, queryByRole } = render(
+      <NotificationProvider>
+        <Harness />
+        <Probe />
+      </NotificationProvider>,
+    );
+
+    // useEffect の tick を待って notification が積まれるのを見届ける
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(seen.ids.length).toBe(1);
+    expect(queryByRole("alert")).not.toBeNull();
+
+    fireEvent.click(getByRole("button"));
+
+    // handleClose は setTimeout(..., 300) で removeNotification を呼ぶ
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(seen.ids.length).toBe(0);
+  });
+
+  test("autoClose schedules removal via setTimeout (verified by mocking setTimeout)", () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const calls: Array<{ delay: number; fn: () => void }> = [];
+    const fakeSetTimeout = mock(
+      (fn: () => void, delay: number): ReturnType<typeof setTimeout> => {
+        calls.push({ delay, fn });
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+    );
+    globalThis.setTimeout = fakeSetTimeout as unknown as typeof setTimeout;
+
+    try {
+      renderInProvider(baseProps({ autoClose: true }));
+      // useEffect で NOTIFICATION_DURATION - ANIMATION_DURATION = 4700ms が登録される
+      expect(calls.some((c) => c.delay === 4700)).toBe(true);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+});

--- a/client/src/utils/templateIO.test.ts
+++ b/client/src/utils/templateIO.test.ts
@@ -1,6 +1,17 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import type { Template } from "~/model/template";
-import { validateImportedTemplates } from "./templateIO";
+import { exportTemplates, validateImportedTemplates } from "./templateIO";
+
+const validTemplate: Template = {
+  id: "t1",
+  title: "Title 1",
+  category: {
+    id: "c1",
+    name: "Category 1",
+    box_art_url: "https://example.com/c1.jpg",
+  },
+  tags: ["tag1", "tag2"],
+};
 
 test("validateImportedTemplates returns true for valid template array", () => {
   const validTemplates: Template[] = [
@@ -104,3 +115,95 @@ test("validateImportedTemplates returns false for array with invalid tags", () =
 
   expect(validateImportedTemplates(invalidTemplates)).toBe(false);
 });
+
+// ---- exportTemplates ----
+
+let urlCreateMock: ReturnType<typeof mock>;
+let urlRevokeMock: ReturnType<typeof mock>;
+let originalCreateObjectURL: typeof URL.createObjectURL;
+let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+
+beforeEach(() => {
+  originalCreateObjectURL = URL.createObjectURL;
+  originalRevokeObjectURL = URL.revokeObjectURL;
+  urlCreateMock = mock(() => "blob:mock-url");
+  urlRevokeMock = mock(() => undefined);
+  URL.createObjectURL = urlCreateMock as unknown as typeof URL.createObjectURL;
+  URL.revokeObjectURL = urlRevokeMock as unknown as typeof URL.revokeObjectURL;
+});
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+test("exportTemplates writes JSON blob and triggers download with given filename", async () => {
+  let capturedBlob: Blob | null = null;
+  urlCreateMock = mock((blob: Blob) => {
+    capturedBlob = blob;
+    return "blob:mock-url";
+  });
+  URL.createObjectURL = urlCreateMock as unknown as typeof URL.createObjectURL;
+
+  const clickSpy = mock(() => undefined);
+  const origCreateElement = document.createElement.bind(document);
+  const createElementSpy = mock((tag: string) => {
+    const el = origCreateElement(tag) as HTMLAnchorElement;
+    if (tag === "a") el.click = clickSpy as unknown as typeof el.click;
+    return el;
+  });
+  document.createElement =
+    createElementSpy as unknown as typeof document.createElement;
+
+  try {
+    exportTemplates([validTemplate], "custom.json");
+
+    expect(urlCreateMock).toHaveBeenCalledTimes(1);
+    expect(capturedBlob).not.toBeNull();
+    expect((capturedBlob as unknown as Blob).type).toBe("application/json");
+
+    const text = await (capturedBlob as unknown as Blob).text();
+    expect(JSON.parse(text)).toEqual([validTemplate]);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(urlRevokeMock).toHaveBeenCalledWith("blob:mock-url");
+  } finally {
+    document.createElement = origCreateElement;
+  }
+});
+
+test("exportTemplates defaults filename to templates.json", () => {
+  const origCreateElement = document.createElement.bind(document);
+  let capturedDownload = "";
+  const createElementSpy = mock((tag: string) => {
+    const el = origCreateElement(tag) as HTMLAnchorElement;
+    if (tag === "a") {
+      el.click = mock(() => undefined) as unknown as typeof el.click;
+      Object.defineProperty(el, "download", {
+        set(v: string) {
+          capturedDownload = v;
+        },
+        get() {
+          return capturedDownload;
+        },
+      });
+    }
+    return el;
+  });
+  document.createElement =
+    createElementSpy as unknown as typeof document.createElement;
+
+  try {
+    exportTemplates([]);
+    expect(capturedDownload).toBe("templates.json");
+  } finally {
+    document.createElement = origCreateElement;
+  }
+});
+
+// Note: importTemplates tests were attempted but the interaction between
+// happy-dom's FileReader and bun:test's async handling was unreliable
+// (intermittent hangs). Since importTemplates is largely a thin wrapper over
+// FileReader + validateImportedTemplates (both covered separately), we skip
+// its integration-style test for now. If needed, a full-DOM e2e or a Playwright
+// test would be a better fit than mocking FileReader here.


### PR DESCRIPTION
## Summary

- `client/src/utils/templateIO.ts`: 21.84% → 42.11% (exportTemplates のテスト追加)
- `client/src/Notification/NotificationBanner.tsx`: 2.56% → 99.40% (包括テスト追加)
- 全体: 209 pass → 221 pass

## 詳細

### templateIO
- `exportTemplates`: Blob の type と JSON content を assert、URL.createObjectURL/revoke の呼出確認、filename 省略時に templates.json が使われることを確認
- `importTemplates`: Happy DOM の FileReader と bun:test の async 相互作用が不安定だったため断念。理由を code 内 note として残した (必要なら Playwright で e2e 化が適切)

### NotificationBanner
- title/message/role=alert の描画
- type 別 icon 描画 (test.each で success / error / warning / info)
- autoClose 有無での progress bar 描画
- close button クリック時の exit animation (translate-x-full + opacity-0)
- close button → handleClose の setTimeout(300ms) 後に provider state から削除されること
- autoClose 時に setTimeout(4700ms) が登録されること (mock で observe)

## Test plan

- [ ] CI の check:test pass (221 pass, 0 fail)
- [ ] check:lint / check:type pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)