### PR TITLE
fix(client): 初回ログインで Entrance に弾かれる Bearer race を解消

### DIFF
--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -11,7 +11,7 @@ import {
 import { SWRConfig } from "swr";
 import { getAuthProvider } from "~/auth";
 import { APP_BASE_URL } from "~/constant";
-import { setIdTokenForTrpc, trpc } from "~/trpc/client";
+import { ID_TOKEN_STORAGE_KEY, trpc } from "~/trpc/client";
 import { useSession } from "~/useStorage";
 import { type AuthToken, TwitchAuthContext } from "./context";
 import {
@@ -71,7 +71,7 @@ export const TwitchAuthProvider: FC<Props> = ({
   const [accessToken, setAccessToken, removeAccessToken] =
     useSession<AuthToken>("twitch-auth", "");
   const [idToken, setIdToken, removeIdToken] = useSession<AuthToken>(
-    "twitch-id-token",
+    ID_TOKEN_STORAGE_KEY,
     "",
   );
   const [nonce, setNonce] = useState<string>(ensureNonce);
@@ -83,13 +83,6 @@ export const TwitchAuthProvider: FC<Props> = ({
     retry: false,
     enabled: !!idToken,
   });
-
-  // trpc link に現在の id_token を注入する。sessionStorage の知識は useSession が
-  // 独占し、trpc link は slot を読むだけ。render 毎に同期することで、setIdToken が
-  // 発生した直後の meQuery auto-fetch でも最新値が Bearer に乗る。
-  useEffect(() => {
-    setIdTokenForTrpc(idToken || null);
-  }, [idToken]);
 
   /**
    * 現 nonce を消費し、次回ログイン用に新しい nonce を発行する。

--- a/client/src/trpc/client.test.ts
+++ b/client/src/trpc/client.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ID_TOKEN_STORAGE_KEY, readIdToken } from "./client";
+
+describe("readIdToken", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  test("returns null when no token in storage", () => {
+    expect(readIdToken()).toBeNull();
+  });
+
+  test("returns the token string when useSession-format JSON is stored", () => {
+    // useSession は JSON.stringify で書き込むため、文字列値は二重引用符付きで入る
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify("ey.token"));
+    expect(readIdToken()).toBe("ey.token");
+  });
+
+  test("returns null when storage value is empty string (JSON-stringified)", () => {
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(""));
+    expect(readIdToken()).toBeNull();
+  });
+
+  test("returns null when storage value is invalid JSON", () => {
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, "not-a-json{");
+    expect(readIdToken()).toBeNull();
+  });
+
+  test("returns null when storage value parses to non-string (e.g., number)", () => {
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(42));
+    expect(readIdToken()).toBeNull();
+  });
+
+  test("returns null when storage value parses to null", () => {
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(null));
+    expect(readIdToken()).toBeNull();
+  });
+
+  test("reads synchronously (fetch 発行タイミングと独立)", () => {
+    // 本 fix の意図: headers() が fetch 発行のたびに同期的に最新値を取れること。
+    // setItem 直後に readIdToken を呼べば新値が見える (useEffect 等を挟まない)。
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify("first"));
+    expect(readIdToken()).toBe("first");
+    sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify("second"));
+    expect(readIdToken()).toBe("second");
+    sessionStorage.removeItem(ID_TOKEN_STORAGE_KEY);
+    expect(readIdToken()).toBeNull();
+  });
+});

--- a/client/src/trpc/client.ts
+++ b/client/src/trpc/client.ts
@@ -5,20 +5,39 @@ import type { AppRouter } from "@twitch-tag-inventory/server/trpc-types";
 export const trpc = createTRPCReact<AppRouter>();
 
 /**
- * 現在の Twitch id_token を保持する mutable slot (ADR 0007)。
- *
- * sessionStorage への read/write は `useSession` が所有しており、trpc link は
- * このモジュールスコープの slot から最新値を読むだけ。`TwitchAuthProvider` が
- * useEffect で `setIdTokenForTrpc(idToken)` を呼んで同期する。
- *
- * こうすることで sessionStorage のシリアライズ形式 (JSON.stringify 経由か生文字列か)
- * の知識を trpc link 側に漏らさずに済む。
+ * Twitch id_token を sessionStorage に保管するキー (ADR 0007)。
+ * `TwitchAuthProvider` の `useSession` と、本 module の `headers()` で共有する。
  */
-let currentIdToken: string | null = null;
+export const ID_TOKEN_STORAGE_KEY = "twitch-id-token";
 
-export const setIdTokenForTrpc = (token: string | null): void => {
-  currentIdToken = token;
-};
+/**
+ * sessionStorage から Twitch id_token を同期的に読む。`useSession` 経由で
+ * JSON.stringify されて書かれているので JSON.parse で unwrap する。
+ *
+ * **なぜ module-level slot ではなく毎回 sessionStorage を読むのか**:
+ * かつては `currentIdToken` という mutable slot + `setIdTokenForTrpc` setter で
+ * provider の useEffect から同期していたが、初回ログイン直後に
+ *   1. Phase A が setIdToken で state 更新 queue
+ *   2. React が re-render、useQuery が enable 化されて fetch を commit 内で schedule
+ *   3. provider の useEffect (`setIdTokenForTrpc`) が passive effect として commit 後に走る
+ *   4. 既に schedule 済の fetch が先に microtask で発火 → `headers()` は古い slot (null) を読み Bearer 無しで送信 → `auth.me` 401
+ * という race が発生していた (「初回ログインで Entrance に弾かれる」症状)。
+ *
+ * `useSession` の setter は `storage.setItem` を同期的に実行するため、
+ * `headers()` で直接 sessionStorage を読めば fetch 発行タイミングに依存せず
+ * 最新 token が得られる。
+ */
+export function readIdToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(ID_TOKEN_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "string" && parsed.length > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 export const trpcClient = trpc.createClient({
   links: [
@@ -26,8 +45,10 @@ export const trpcClient = trpc.createClient({
       url: "/api/trpc",
       // ADR 0007: Twitch id_token を Authorization: Bearer で手動送信。サーバーは
       // 毎リクエスト jose で署名 / iss / aud / exp を検証して identity を resolve する。
-      headers: () =>
-        currentIdToken ? { authorization: `Bearer ${currentIdToken}` } : {},
+      headers: () => {
+        const token = readIdToken();
+        return token ? { authorization: `Bearer ${token}` } : {};
+      },
     }),
   ],
 });


### PR DESCRIPTION
## Summary

初回ログイン時に `auth.me` が Bearer ヘッダ無しで送信され、サーバに 401 扱いされて Entrance に bounce する race を修正する。

## 根本原因

`client/src/trpc/client.ts` の module-level slot (`currentIdToken`) + provider の `useEffect(() => setIdTokenForTrpc(idToken))` で Bearer を同期していたが、以下の順序で race が発生していた:

1. Phase A が `setIdToken(parsed.idToken)` で state 更新を queue
2. React が re-render、`useQuery` の `enabled` が true になり commit 内で fetch を schedule
3. provider の `useEffect`(slot 同期) は passive effect のため commit 後に走る
4. 既に schedule 済の fetch が先に microtask で発火 → `headers()` は古い slot (`null`) を読み **Bearer 無し** で送信
5. サーバが 401 を返し、Phase B が token をクリアして Entrance へ bounce

2 回目のクリックが偶然通る理由: 1 回目失敗で slot が埋まった状態で、次の render-subscribe サイクルで偶然 timing が噛み合うため。構造的には脆い。

## 本番ログの根拠 (11:21 帯)

```
11:21:11.172 auth.me 401         ← 初回ログインの fetch、Bearer 無し
11:21:11.345 templates.sync 401
11:21:12.479 templates.sync 200  ← slot 更新後の別バッチ
11:21:13.640 templates.sync 401  ← Phase B のクリーンアップ経路
...
11:21:37.792 templates.sync 200  ← 2 回目クリック後の成功
11:21:37.802 auth.me 200
```

401 の latency が 5ms 程度 (JWKS fetch / 署名検証より速い) なので、Bearer 自体が無い状態での UNAUTHORIZED と判断。

## 修正

`headers()` で sessionStorage を直接同期的に読む方式に変更。`useSession` の setter は `storage.setItem` を同期的に実行するため、`setIdToken` 直後の fetch でも最新 token が取れる。

- `client/src/trpc/client.ts`: `currentIdToken` / `setIdTokenForTrpc` 削除、`readIdToken()` を追加、`headers()` を毎回読み直しに変更。`ID_TOKEN_STORAGE_KEY` を export して provider と共有
- `client/src/TwitchAuth/provider.tsx`: slot 同期 useEffect を削除、useSession の key を `ID_TOKEN_STORAGE_KEY` に差し替え
- `client/src/trpc/client.test.ts`: `readIdToken` の正常系 / null 系 / JSON 不正 / 同期性の 7 ケース追加 (カバレッジ 56.52% → 91.30%)

## トレードオフ

tRPC link が「useSession は JSON.stringify で書く」という format 知識を持つようになる。ただし key 名は既に共有されており追加結合は小さい (経緯コメントで明記済)。race を構造的に消せる価値の方が大きいと判断。

## Test plan

- [x] type check / lint / unit test pass (228 pass, 0 fail)
- [ ] merge → deploy 後、incognito tab で本番ログイン → 1 発で MainScreen に到達
- [ ] Cloud Run logs で `auth.me` の 401 が消えている

🤖 Generated with [Claude Code](https://claude.com/claude-code)