### PR TITLE
feat(client): 認証中の Loading 画面を中央配置 + スピナー付きに改善

### DIFF
--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { SWRConfig } from "swr";
 import { getAuthProvider } from "~/auth";
+import { LoadingScreen } from "~/components/LoadingScreen";
 import { APP_BASE_URL } from "~/constant";
 import { ID_TOKEN_STORAGE_KEY, trpc } from "~/trpc/client";
 import { useSession } from "~/useStorage";
@@ -162,7 +163,7 @@ export const TwitchAuthProvider: FC<Props> = ({
 
   // --- Render ---
 
-  if (idToken && meQuery.isPending) return <>Loading...</>;
+  if (idToken && meQuery.isPending) return <LoadingScreen />;
 
   // 完全ログイン
   if (idToken && meQuery.data) {
@@ -187,5 +188,5 @@ export const TwitchAuthProvider: FC<Props> = ({
   }
 
   if (authorizeUrl) return <>{entrance(authorizeUrl)}</>;
-  return <>Loading...</>;
+  return <LoadingScreen />;
 };

--- a/client/src/components/LoadingScreen.test.tsx
+++ b/client/src/components/LoadingScreen.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { I18nWrapper } from "~/test-utils";
+import { LoadingScreen } from "./LoadingScreen";
+
+describe("LoadingScreen", () => {
+  test("renders brand title and default loading label (en)", () => {
+    const { getByRole, getByText } = render(<LoadingScreen />, {
+      wrapper: I18nWrapper,
+    });
+
+    const status = getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(getByText("Stream Tag Inventory")).toBeInTheDocument();
+    // 既定言語 (`i18n/config.ts` の detect) — test では en で初期化される想定。
+    // label 文字列そのものを詮索せず common.loading key の両言語いずれかが出れば OK。
+    const loadingEl = status.querySelector("p");
+    expect(loadingEl?.textContent).toMatch(/Loading|読み込み中/);
+  });
+
+  test("renders custom label when provided", () => {
+    const { getByText } = render(<LoadingScreen label="Signing in..." />, {
+      wrapper: I18nWrapper,
+    });
+    expect(getByText("Signing in...")).toBeInTheDocument();
+  });
+
+  test("spinner element is aria-hidden", () => {
+    const { container } = render(<LoadingScreen />, { wrapper: I18nWrapper });
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).not.toBeNull();
+    expect(spinner?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("status region has aria-live polite for screen readers", () => {
+    const { getByRole } = render(<LoadingScreen />, { wrapper: I18nWrapper });
+    expect(getByRole("status").getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/client/src/components/LoadingScreen.tsx
+++ b/client/src/components/LoadingScreen.tsx
@@ -1,0 +1,31 @@
+import type { FC } from "react";
+import { useTranslation } from "~/i18n";
+
+type Props = {
+  /** 下部テキストを差し替える場合。省略時は t("common.loading") */
+  label?: string;
+};
+
+/**
+ * 認証後の identity resolve 待ち等、短時間の全画面 loading 表示に使う。
+ * Entrance と同じブランドタイトルを見せ、スピナー + 控えめな loading ラベルを添える。
+ */
+export const LoadingScreen: FC<Props> = ({ label }) => {
+  const { t } = useTranslation();
+  return (
+    <main
+      className="h-screen w-screen flex flex-col items-center justify-center bg-surface"
+      role="status"
+      aria-live="polite"
+    >
+      <h1 className="text-4xl font-bold">Stream Tag Inventory</h1>
+      <div
+        className="mt-8 h-8 w-8 rounded-full border-2 border-slate-200 border-t-sky-600 animate-spin"
+        aria-hidden="true"
+      />
+      <p className="mt-4 text-sm text-slate-500">
+        {label ?? t("common.loading")}
+      </p>
+    </main>
+  );
+};


### PR DESCRIPTION
## Summary

これまでの裸の `<>Loading...</>` (画面左上にテキストだけ) を、Entrance と揃えた中央配置のデザインに差し替える。

- ブランドタイトル "Stream Tag Inventory" (Entrance と同じ `text-4xl font-bold`)
- 回転スピナー (Tailwind builtin `animate-spin` + `border-t-sky-600` トリック、追加 CSS 無し)
- i18n 対応のローディングテキスト (既存 `common.loading` key を流用)
- `role="status"` + `aria-live="polite"` でスクリーンリーダー対応

## 変更

- `client/src/components/LoadingScreen.tsx` 新規 (再利用可能な shared component として配置。`label` prop で差し替え可能 — 将来 templates sync 待ち等に使える)
- `client/src/components/LoadingScreen.test.tsx` 新規 (既定 label / カスタム label / aria-hidden spinner / aria-live polite の 4 ケース、100% cover)
- `client/src/TwitchAuth/provider.tsx`: 2 箇所の Loading fallback を `<LoadingScreen />` に差し替え

## Test plan

- [x] type check / lint / unit test pass (232 pass, 0 fail)
- [ ] deploy 後、本番 (incognito tab) でログイン遷移中に中央配置のローディング画面が一瞬見えることを目視確認
- [ ] meQuery を人為的に遅延させると `Stream Tag Inventory` タイトル + スピナー + 読み込み中... が中央に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)