### PR TITLE
fix(client): stale meQuery error が Phase B を誤発動させて初回ログインを bounce させる問題を解消

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { TRPCLink } from "@trpc/client";
+import { observable } from "@trpc/server/observable";
+import type { FC, ReactNode } from "react";
+import { I18nWrapper } from "~/test-utils";
+import { ID_TOKEN_STORAGE_KEY, trpc } from "~/trpc/client";
+import { TwitchAuthProvider } from "./provider";
+
+/**
+ * peekIdTokenNonce が parse できる "JWT 風" 文字列を組み立てる。
+ * 署名検証は本 provider の責務ではなく server 側なので、payload だけ意味があれば良い。
+ */
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64url = (s: string) =>
+    btoa(s).replace(/=+$/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+/**
+ * auth.me の応答を「その時点で sessionStorage にある id_token」に応じて
+ * 切り替える custom link。httpBatchLink の代わりにこれを挿すことで、
+ * fetch の実挙動 (headers が dispatch 時に評価される) を mock しつつ、
+ * Bearer 値による挙動分岐を直接制御する。
+ *
+ * ログを calls[] に残すので、呼び出し順序と token も assert できる。
+ */
+type AuthMeResponder = (
+  bearer: string | null,
+) => { ok: true; data: unknown } | { ok: false };
+
+// biome-ignore lint/suspicious/noExplicitAny: TRPCLink generics は AppRouter 型に依存し、テストでは雑に any で流す
+function createMockLink(authMeResponder: AuthMeResponder): {
+  link: TRPCLink<any>;
+  calls: Array<{ path: string; bearer: string | null }>;
+} {
+  const calls: Array<{ path: string; bearer: string | null }> = [];
+  // biome-ignore lint/suspicious/noExplicitAny: 同上
+  const link: TRPCLink<any> =
+    () =>
+    ({ op }) =>
+      observable((observer) => {
+        const raw = sessionStorage.getItem(ID_TOKEN_STORAGE_KEY);
+        let bearer: string | null = null;
+        if (raw) {
+          try {
+            const parsed = JSON.parse(raw);
+            if (typeof parsed === "string" && parsed.length > 0)
+              bearer = parsed;
+          } catch {
+            // ignore
+          }
+        }
+        calls.push({ path: op.path, bearer });
+
+        if (op.path === "auth.me") {
+          const res = authMeResponder(bearer);
+          if (res.ok) {
+            observer.next({ result: { data: res.data } });
+            observer.complete();
+          } else {
+            observer.error(
+              new Error("UNAUTHORIZED") as unknown as Parameters<
+                typeof observer.error
+              >[0],
+            );
+          }
+          return;
+        }
+
+        // 他の procedure は空応答で成功させる (templates.sync など。テスト対象外)
+        observer.next({ result: { data: null } });
+        observer.complete();
+      });
+  return { link, calls };
+}
+
+const Providers: FC<{
+  children: ReactNode;
+  queryClient: QueryClient;
+  // biome-ignore lint/suspicious/noExplicitAny: 同上
+  link: TRPCLink<any>;
+}> = ({ children, queryClient, link }) => {
+  const client = trpc.createClient({ links: [link] });
+  return (
+    <I18nWrapper>
+      <trpc.Provider client={client} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </trpc.Provider>
+    </I18nWrapper>
+  );
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+  window.location.hash = "";
+});
+
+/**
+ * 再現テスト: sessionStorage に stale id_token が残っている状態で、URL hash に
+ * 新しい id_token を持って callback 戻り → 最終的に MainScreen (AUTHENTICATED)
+ * に到達すべき。
+ *
+ * バグ: Phase A で NEW token に差し替わったあと、meQuery が前 token の 401 error
+ * 状態を保持したままで Phase B が発火 → NEW token も clear されて Entrance bounce。
+ * ユーザは 2 度ログインしないといけない症状として現れる。
+ */
+test("stale id_token + callback hash で 2 度ログイン不要 (regression)", async () => {
+  const oldNonce = "nonce-old";
+  const newNonce = "nonce-new";
+  const oldIdToken = fakeJwt({ nonce: oldNonce, sub: "u1" });
+  const newIdToken = fakeJwt({ nonce: newNonce, sub: "u1" });
+
+  sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(oldIdToken));
+  sessionStorage.setItem("twitch-auth", JSON.stringify("old-access"));
+  sessionStorage.setItem("oauth_nonce", newNonce);
+  window.location.hash = `#access_token=new-access&id_token=${newIdToken}&token_type=bearer&expires_in=14400`;
+
+  // Bearer が OLD → UNAUTHORIZED, NEW → user 情報を返す
+  const { link, calls } = createMockLink((bearer) => {
+    if (bearer === newIdToken) {
+      return {
+        ok: true,
+        data: {
+          user: {
+            id: "u1",
+            twitchUserId: "u1",
+            login: "u",
+            displayName: "U",
+          },
+        },
+      };
+    }
+    return { ok: false };
+  });
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const { findByText, queryByText } = render(
+    <Providers queryClient={queryClient} link={link}>
+      <TwitchAuthProvider
+        scope={["user:edit:broadcast"]}
+        entrance={() => <div>ENTRANCE</div>}
+      >
+        <div>AUTHENTICATED</div>
+      </TwitchAuthProvider>
+    </Providers>,
+  );
+
+  const authed = await findByText("AUTHENTICATED", {}, { timeout: 3000 });
+  expect(authed).toBeInTheDocument();
+  expect(queryByText("ENTRANCE")).toBeNull();
+
+  // 診断: OLD Bearer で auth.me が走ったこと + 最終的に NEW Bearer で 200 取ったこと
+  const authMeCalls = calls.filter((c) => c.path === "auth.me");
+  expect(authMeCalls.length).toBeGreaterThanOrEqual(1);
+  expect(authMeCalls.some((c) => c.bearer === newIdToken)).toBe(true);
+});

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -78,6 +78,7 @@ export const TwitchAuthProvider: FC<Props> = ({
   const [nonce, setNonce] = useState<string>(ensureNonce);
   const callbackHandledRef = useRef(false);
   const queryClient = useQueryClient();
+  const utils = trpc.useUtils();
 
   // idToken が空の間は無効 (`enabled: false`) で 401 ノイズを抑制する。
   const meQuery = trpc.auth.me.useQuery(undefined, {
@@ -121,19 +122,37 @@ export const TwitchAuthProvider: FC<Props> = ({
     rotateNonce();
     setAccessToken(parsed.accessToken);
     setIdToken(parsed.idToken);
+    // 前 session の stale id_token が storage に残っていた場合、mount 時に
+    // meQuery が OLD Bearer で fetch 済みで 401 を返しつつある状況がある。
+    // そのまま放置すると Phase B が isError を見て NEW token 一式を clear して
+    // しまうため、in-flight を cancel + state を reset して NEW token での
+    // fresh な fetch を強制する。
+    void utils.auth.me.cancel();
+    utils.auth.me.reset();
     // 直後に meQuery が enable 化して identity を取りに行く
   }, []);
 
   // Phase B: idToken 有 + meQuery 401 → 期限切れ or サーバー側で reject。
   // 両方クリア + 新 nonce 発行して Entrance へ落とす。
+  //
+  // isFetching=true の間は cleanup を待つ。Phase A の reset 直後に refetch が
+  // 走っている最中で、前 token の stale error を見て誤発動することを防ぐ。
+  // fetch が終わって isError=true のままなら本当に reject されたと判断してよい。
   useEffect(() => {
-    if (idToken && meQuery.isError) {
+    if (idToken && meQuery.isError && !meQuery.isFetching) {
       console.warn("id_token rejected by server; clearing local tokens");
       removeIdToken();
       removeAccessToken();
       rotateNonce();
     }
-  }, [idToken, meQuery.isError, removeIdToken, removeAccessToken, rotateNonce]);
+  }, [
+    idToken,
+    meQuery.isError,
+    meQuery.isFetching,
+    removeIdToken,
+    removeAccessToken,
+    rotateNonce,
+  ]);
 
   // scope は呼出側で毎レンダー新しい配列になり得るので、内容ベースの key で deps 化。
   // string が同じなら React の Object.is 比較で useMemo は前回の値を維持する。


### PR DESCRIPTION
## Summary

ユーザが 1 度ログインすると Entrance に戻され、2 度目でようやく通る問題の根本原因を修正する。PR #89 では `currentIdToken` slot の race を疑って sessionStorage 直読みに変えたが、それは症状の一部しか説明できておらず真の原因は別だった。

## 真の原因

sessionStorage に前 session の **stale id_token** が残っている状態で callback (hash 付き) が戻ってくると、以下の順序で Phase B が誤発動する:

1. Mount: `useSession` の lazy init が storage から stale `idToken=OLD` を読む
2. `meQuery` が `enabled=!!OLD` で fetch 開始 → Bearer OLD で `auth.me` を叩く
3. Phase A useEffect が hash を parse し、`setIdToken(NEW)` で storage + state を更新
4. Re-render: `idToken=NEW`。meQuery は in-flight のまま
5. OLD Bearer の fetch が 401 で返る → `meQuery.isError=true`
6. Phase B useEffect が発火: `idToken && isError` → **NEW token を道連れに clear**
7. Entrance に bounce

Phase B の `idToken && meQuery.isError` は「**過去の** idToken で 401 が残っているだけ」のケースと「**現在の** idToken が reject された」ケースを区別できなかった。

## 修正

1. **Phase A で idToken 差し替え直後に meQuery を cancel + reset**
   `utils.auth.me.cancel()` で in-flight の OLD fetch を破棄、`utils.auth.me.reset()` で state (特に `isError`) を初期化。reset 直後に NEW token で自動 refetch される。

2. **Phase B に `!meQuery.isFetching` ガードを追加**
   refetch 中の stale error で誤発動しないよう、fetch が終わった上で `isError` が立っている場合のみ cleanup する。

## Regression test

`client/src/TwitchAuth/provider.test.tsx` を新設。カスタム tRPC link で Bearer 値に応じて `auth.me` を 401/200 切替させ、stale id_token + callback hash の状態を再現。

- **fix 無し**: ENTRANCE に bounce、`AUTHENTICATED` が表示されず test timeout → fail (= バグ再現)
- **fix 有り**: `AUTHENTICATED` が表示されて pass

両挙動を local で確認済み。

## Test plan

- [x] type / lint / unit test pass (233 pass, 0 fail)
- [x] regression test が fix 適用前は fail、適用後は pass になることを確認済
- [ ] deploy 後、本番で sessionStorage に古い id_token が残ったまま再ログインして 1 回で通ることを目視確認

## 関連 PR

- PR #89: 先に投入した `headers()` の sessionStorage 直読み化。race の 1 経路は救うが、今回の stale-error 経路は救えなかった。両方 merge された状態で完全に塞がれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)