### PR TITLE
fix(client): Twitch の nonce cache 起因の「2 度ログイン」を auto-retry で解消

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -40,8 +40,8 @@ type AuthMeResponder = (
   bearer: string | null,
 ) => { ok: true; data: unknown } | { ok: false };
 
-// biome-ignore lint/suspicious/noExplicitAny: TRPCLink generics は AppRouter 型に依存し、テストでは雑に any で流す
 function createMockLink(authMeResponder: AuthMeResponder): {
+  // biome-ignore lint/suspicious/noExplicitAny: TRPCLink generics は AppRouter 型に依存し、テストでは雑に any で流す
   link: TRPCLink<any>;
   calls: Array<{ path: string; bearer: string | null }>;
 } {
@@ -125,14 +125,21 @@ function renderWithProvider(
   return { ...result, calls, queryClient };
 }
 
+/**
+ * 前の test が `window.location.href = <authorize url>` で navigate した状態が
+ * 残ると、次の test の `window.location.href` 観測が壊れる。happy-dom では
+ * href 代入が actual reload を起こさず URL 文字列だけ変わるため、明示的に
+ * localhost へ戻す。
+ */
+const BASE_URL = "http://localhost:3000/";
 beforeEach(() => {
   sessionStorage.clear();
-  window.location.hash = "";
+  window.location.href = BASE_URL;
 });
 
 afterEach(() => {
   sessionStorage.clear();
-  window.location.hash = "";
+  window.location.href = BASE_URL;
 });
 
 // =============================================================================
@@ -242,11 +249,44 @@ test("session expired (valid token in storage but server 401): Phase B cleans up
 // Nonce / callback validation
 // =============================================================================
 
-test("nonce mismatch in callback id_token → Entrance (no tokens saved, nonce rotated)", async () => {
-  // sessionStorage.oauth_nonce と id_token claim.nonce が異なるケース = mix-up
+test("nonce mismatch in callback id_token → auto-retry by navigating to authorize URL (regression #93-follow-up)", async () => {
+  // Twitch が前セッションの id_token を cache して、新しい nonce で authorize
+  // しても stale な nonce claim の id_token を返すケース。手で 2 度 login ボタンを
+  // 押せば成功するが UX が悪い。mismatch 検出時に client 側で自動的に再 authorize
+  // することで 1 クリックで login 完了させる。
   sessionStorage.setItem("oauth_nonce", "expected-nonce");
-  const bogusIdToken = fakeJwt({ nonce: "attacker-nonce", sub: "u1" });
+  const bogusIdToken = fakeJwt({ nonce: "stale-nonce", sub: "u1" });
   window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer&expires_in=14400`;
+  const originalHref = window.location.href;
+
+  renderWithProvider(() => ({ ok: true, data: { user: DEFAULT_USER } }));
+
+  await waitFor(
+    () => {
+      // Phase A が mismatch を検出して window.location.href を authorize URL に
+      // 向け直すことを確認
+      expect(window.location.href).not.toBe(originalHref);
+    },
+    { timeout: 1500 },
+  );
+  expect(window.location.href).toContain("id.twitch.tv/oauth2/authorize");
+
+  // token は保存されていない (stale token を拒否)
+  expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
+  expect(sessionStorage.getItem("twitch-auth")).toBeNull();
+  // nonce は rotate 済 (次の authorize は fresh な値で走る)
+  expect(sessionStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
+  // auto-retry 用のカウンタが sessionStorage に立つ
+  expect(sessionStorage.getItem("oauth_retry_count")).toBe("1");
+});
+
+test("nonce mismatch が連続した場合、MAX_AUTO_RETRIES で auto-retry を停止して Entrance を出す", async () => {
+  // 攻撃者が執拗に stale token を inject し続ける or Twitch が壊れてる等で
+  // 無限 retry loop を避けるガード。
+  sessionStorage.setItem("oauth_nonce", "expected");
+  sessionStorage.setItem("oauth_retry_count", "2"); // 既に MAX 到達
+  const bogusIdToken = fakeJwt({ nonce: "stale", sub: "u1" });
+  window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer`;
 
   const { findByText } = renderWithProvider(() => ({
     ok: true,
@@ -254,11 +294,34 @@ test("nonce mismatch in callback id_token → Entrance (no tokens saved, nonce r
   }));
 
   expect(await findByText("ENTRANCE")).toBeInTheDocument();
-  // token が保存されていない
+  // retry 上限のため navigate はしない (href が id.twitch.tv/authorize 形式に
+  // なっていないこと、すなわち自 origin のままであることを確認)
+  expect(window.location.href).not.toContain("id.twitch.tv/oauth2/authorize");
+  // retry counter は reset される (次回の新規 login でまた 0 から数える)
+  expect(sessionStorage.getItem("oauth_retry_count")).toBeNull();
   expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
-  expect(sessionStorage.getItem("twitch-auth")).toBeNull();
-  // nonce は rotate 済 (攻撃用 nonce を再利用されない)
-  expect(sessionStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
+});
+
+test("nonce が一致して login 成功した場合、oauth_retry_count はクリアされる", async () => {
+  // auto-retry で 1 回目 mismatch → navigate → 2 回目 callback が一致して成功、
+  // というシーケンスの後半を模擬する。retry_count=1 の状態から成功すれば 0 に
+  // リセットされ、次回 login は fresh な状態から始まる。
+  const nonce = "match";
+  const idToken = fakeJwt({ nonce, sub: "u1" });
+  sessionStorage.setItem("oauth_nonce", nonce);
+  sessionStorage.setItem("oauth_retry_count", "1");
+  window.location.hash = `#access_token=at&id_token=${idToken}&token_type=bearer`;
+
+  const { findByText } = renderWithProvider((bearer) =>
+    bearer === idToken
+      ? { ok: true, data: { user: DEFAULT_USER } }
+      : { ok: false },
+  );
+
+  expect(
+    await findByText("AUTHENTICATED", {}, { timeout: 3000 }),
+  ).toBeInTheDocument();
+  expect(sessionStorage.getItem("oauth_retry_count")).toBeNull();
 });
 
 test("malformed id_token (can't parse nonce) → Entrance (no tokens saved)", async () => {

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -24,6 +24,13 @@ import {
 
 /** nonce を Twitch redirect 往復の間に保管する sessionStorage key */
 const NONCE_STORAGE_KEY = "oauth_nonce";
+/**
+ * nonce mismatch 時に auto-retry した回数を保持する sessionStorage key。
+ * Twitch が前 session の id_token を cache して stale nonce で返すバグの
+ * 回避策として用いる。MAX を超えたら retry 停止して Entrance を出す。
+ */
+const RETRY_COUNT_STORAGE_KEY = "oauth_retry_count";
+const MAX_AUTO_RETRIES = 2;
 
 /**
  * mount 時点で sessionStorage に nonce が無ければ同期的に発行する。
@@ -110,15 +117,50 @@ export const TwitchAuthProvider: FC<Props> = ({
 
     const claimNonce = peekIdTokenNonce(parsed.idToken);
     if (claimNonce !== nonce) {
-      // mix-up 攻撃 or sessionStorage が途中でクリアされた等。callback を破棄
-      // して新しい nonce で Entrance をやり直させる。
-      console.warn("id_token nonce mismatch; rejecting Twitch callback");
-      callbackHandledRef.current = false;
+      // Twitch のキャッシュ問題で stale nonce の id_token が返されることがある
+      // (前タブで login 成功 → タブ close → 新タブで login すると再現)。ユーザが
+      // もう一度 login ボタンを手動でクリックすれば成功するが UX が悪いので、
+      // mismatch を検出したら自動的に authorize URL へ再 navigate する。
+      //
+      // mix-up 攻撃の場合でも、再 navigate は Twitch が fresh token を返すだけ
+      // なので security 上のリスクは無い (stale token は破棄される)。
+      //
+      // ただし無限 retry ループを避けるため MAX_AUTO_RETRIES で打ち切り、
+      // 上限到達時は通常通り Entrance に戻してユーザの再操作を待つ。
+      const retryCount = Number(
+        sessionStorage.getItem(RETRY_COUNT_STORAGE_KEY) ?? "0",
+      );
+      if (retryCount >= MAX_AUTO_RETRIES) {
+        console.warn(
+          `id_token nonce mismatch; auto-retry exhausted (${retryCount}/${MAX_AUTO_RETRIES})`,
+        );
+        sessionStorage.removeItem(RETRY_COUNT_STORAGE_KEY);
+        callbackHandledRef.current = false;
+        rotateNonce();
+        return;
+      }
+      console.warn(
+        `id_token nonce mismatch; auto-retrying (${retryCount + 1}/${MAX_AUTO_RETRIES})`,
+      );
+      sessionStorage.setItem(RETRY_COUNT_STORAGE_KEY, String(retryCount + 1));
       rotateNonce();
+      const freshNonce =
+        sessionStorage.getItem(NONCE_STORAGE_KEY) ?? generateNonce();
+      const provider = getAuthProvider({
+        get: () => idToken,
+        set: setIdToken,
+        remove: removeIdToken,
+      });
+      window.location.href = provider.getEntranceUri(
+        `${APP_BASE_URL}/`,
+        scope,
+        freshNonce,
+      );
       return;
     }
 
-    // 一致 → consume + 次回用に新規発行
+    // 一致 → consume + 次回用に新規発行 + retry counter を reset
+    sessionStorage.removeItem(RETRY_COUNT_STORAGE_KEY);
     rotateNonce();
     setAccessToken(parsed.accessToken);
     setIdToken(parsed.idToken);


### PR DESCRIPTION
## Summary

ユーザ報告の具体的な症状:
> 1 度ログイン成功 → そのタブを閉じる → 新タブで tags.yuniruyuni.net を開く → Entrance → login クリック → 即座に戻る → URL 除去 → **しかし Entrance に戻る** → もう 1 度 login で成功

Console log: `id_token nonce mismatch; rejecting Twitch callback`

## 原因: Twitch の id_token cache

Twitch OAuth server は (user, client_id) 単位で id_token をキャッシュしており、新しい `nonce` パラメータで authorize しても **stale な nonce claim を持つ id_token を返すことがある**。これは新タブからの初回 login 直後に顕著に再現する。

Client 側は OIDC 仕様通り nonce 照合をしており、stale nonce を検出したら callback を破棄する (= Entrance にフォールバック)。そのため:

1. 1 回目 click → Twitch が stale token を返す → mismatch → Entrance 表示
2. ユーザが 2 回目 click → Twitch が fresh token を返す (cache miss) → 成功

という 2 クリック必須の UX になっていた。

## 修正: Auto-retry on nonce mismatch

Phase A で mismatch を検出した場合、`window.location.href = authorize_url` で **自動的に再 authorize 要求を発行** する。ユーザから見ると「click → Twitch → 戻ってくる → 一瞬して MainScreen」と 1 クリックで完結する (内部的には 2 回 authorize を打っているが体感はスムーズ)。

### Security 上の考察

mix-up 攻撃で stale id_token を inject されるケースでも、auto-retry は Twitch から fresh token を取り直すだけなので安全。attacker's token は client 側に保存されず、retry 後の fresh token で置き換わる。

### 無限 ループ防止

`oauth_retry_count` sessionStorage key で retry 回数を記録し、`MAX_AUTO_RETRIES=2` で打ち切り。上限到達時は従来通り Entrance に戻してユーザの手動再操作を待つ。login 成功時に counter をクリア。

## Regression test (3 件)

- **nonce mismatch → authorize URL への auto-navigation** を assert
- **MAX_AUTO_RETRIES 到達 → Entrance + counter クリア** を assert (無限ループ防止のガード確認)
- **成功経路 → counter クリア** を assert (次回 login が fresh な状態から始まること確認)

fix 前は 3 件とも fail、fix 後は pass することを local で確認済。

## これまでの login fix の分担

| PR | カバー経路 |
|---|---|
| #89 | 初回 mount 時の Bearer race (sessionStorage 直読み) |
| #91 | stale id_token + callback → Phase A→B race (cancel+reset) |
| #93 | network error で Phase B 誤発動 (HTTP 401 限定) |
| **本 PR** | Twitch の id_token cache → nonce mismatch (auto-retry) |

これで「1 度ログイン成功 → タブ閉じ → 新タブ login」の典型シナリオが 1 クリックで通る想定です。

## Test plan

- [x] type / lint / unit test pass (245 pass, 0 fail)
- [x] regression test が fix 前 fail / fix 後 pass を local で確認
- [ ] deploy 後、本番で
  - 1 度 login して成功を確認
  - そのタブを閉じる
  - 新タブで tags.yuniruyuni.net を開く
  - login → MainScreen に 1 クリックで到達することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)