### PR TITLE
chore(client): nonce mismatch 警告に claimed/expected 値を追記して根本原因を特定可能にする

### DIFF
--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -130,9 +130,14 @@ export const TwitchAuthProvider: FC<Props> = ({
       const retryCount = Number(
         sessionStorage.getItem(RETRY_COUNT_STORAGE_KEY) ?? "0",
       );
+      // 根本原因 (Twitch の cache バグ vs URL encoding vs 別事象) の特定用に
+      // claim / expected の両値を出す。auto-retry の navigation で console が
+      // 消えるため、DevTools Console の "Preserve log upon navigation" を ON
+      // にしてから再現する。
+      const nonceDiag = `claimed=${claimNonce ?? "<null>"} expected=${nonce}`;
       if (retryCount >= MAX_AUTO_RETRIES) {
         console.warn(
-          `id_token nonce mismatch; auto-retry exhausted (${retryCount}/${MAX_AUTO_RETRIES})`,
+          `id_token nonce mismatch; auto-retry exhausted (${retryCount}/${MAX_AUTO_RETRIES}) ${nonceDiag}`,
         );
         sessionStorage.removeItem(RETRY_COUNT_STORAGE_KEY);
         callbackHandledRef.current = false;
@@ -140,7 +145,7 @@ export const TwitchAuthProvider: FC<Props> = ({
         return;
       }
       console.warn(
-        `id_token nonce mismatch; auto-retrying (${retryCount + 1}/${MAX_AUTO_RETRIES})`,
+        `id_token nonce mismatch; auto-retrying (${retryCount + 1}/${MAX_AUTO_RETRIES}) ${nonceDiag}`,
       );
       sessionStorage.setItem(RETRY_COUNT_STORAGE_KEY, String(retryCount + 1));
       rotateNonce();


### PR DESCRIPTION
## Summary

PR #94 の auto-retry は症状を解消したが、真因 (Twitch cache / URL encoding / 別事象) はまだ推測段階。観測用に `console.warn` へ値を追記する。

## 変更

\`\`\`ts
// Before
console.warn(\`id_token nonce mismatch; auto-retrying (\${n}/\${MAX})\`);

// After
console.warn(\`id_token nonce mismatch; auto-retrying (\${n}/\${MAX}) claimed=\${claimNonce} expected=\${nonce}\`);
\`\`\`

## 観測方法

auto-retry の navigation で console が消えるため、DevTools で "Preserve log upon navigation" を ON にしてから再現する:

- Chrome: Console タブ右上の設定歯車 → "Preserve log"
- Firefox: Console タブ設定 → "Persist Logs"

## 期待する診断結果

| 出力パターン | 示唆される原因 |
|---|---|
| \`claimed=<別の完全な UUID> expected=<UUID>\` | Twitch 側で id_token を cache している (前 session 分を返却) |
| \`claimed=<null>\` | id_token に nonce claim が載っていない (仕様非準拠 / 実装バグ) |
| 1-2 文字だけ違う | URL encoding / truncation (client 側の authorize URL 生成ミス) |

原因確定後、auto-retry を force_verify=true や nonce check 緩和などの根本 fix で置き換える予定。

## Test plan

- [x] log 追記のみで挙動変更なし、既存 245 テスト pass
- [ ] deploy 後、mismatch 症状を再現してもらい両 nonce の値を共有

🤖 Generated with [Claude Code](https://claude.com/claude-code)