### PR TITLE
chore(client): nonce mismatch の真因調査用に全イベントを console タイムラインで出す

### DIFF
--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -33,15 +33,32 @@ const RETRY_COUNT_STORAGE_KEY = "oauth_retry_count";
 const MAX_AUTO_RETRIES = 2;
 
 /**
+ * 診断ログ。nonce mismatch の真因調査用に ensureNonce / rotateNonce /
+ * Phase A の各イベント発火時点で console.log する。mismatch 検知時点では
+ * 既に storage が rewrite 済みのため、イベントが起きた瞬間に記録しないと
+ * 真相が追えない。
+ *
+ * 再現時は DevTools Console の "Preserve log upon navigation" を ON にして
+ * これらの行を時系列で追う。prefix `[auth]` で grep しやすくしてある。
+ */
+function diag(msg: string): void {
+  console.log(`[auth] ${msg}`);
+}
+
+/**
  * mount 時点で sessionStorage に nonce が無ければ同期的に発行する。
  * useState の lazy init は first render の前に走るため、authorize URL を組み
  * 立てる時点で必ず sessionStorage に nonce が居る状態が保証される。
  */
 function ensureNonce(): string {
   const existing = sessionStorage.getItem(NONCE_STORAGE_KEY);
-  if (existing) return existing;
+  if (existing) {
+    diag(`ensureNonce read=${existing} (no gen)`);
+    return existing;
+  }
   const fresh = generateNonce();
   sessionStorage.setItem(NONCE_STORAGE_KEY, fresh);
+  diag(`ensureNonce read=<null> generated=${fresh}`);
   return fresh;
 }
 
@@ -98,10 +115,12 @@ export const TwitchAuthProvider: FC<Props> = ({
    * sessionStorage と React state の両方を同期的に更新する。
    */
   const rotateNonce = useCallback(() => {
+    const before = sessionStorage.getItem(NONCE_STORAGE_KEY);
     sessionStorage.removeItem(NONCE_STORAGE_KEY);
     const fresh = generateNonce();
     sessionStorage.setItem(NONCE_STORAGE_KEY, fresh);
     setNonce(fresh);
+    diag(`rotateNonce before=${before ?? "<null>"} after=${fresh}`);
   }, []);
 
   // Phase A (one-shot): Twitch callback の URL fragment を消費し、id_token と
@@ -109,13 +128,22 @@ export const TwitchAuthProvider: FC<Props> = ({
   // StrictMode の double-invoke もガード。
   // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on mount
   useEffect(() => {
+    diag(
+      `phaseA enter hash=${window.location.hash ? "present" : "<empty>"} state.nonce=${nonce} storage.nonce=${sessionStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"} callbackHandled=${callbackHandledRef.current}`,
+    );
     if (callbackHandledRef.current) return;
     const parsed = parseAuthFromHash();
-    if (!parsed) return;
+    if (!parsed) {
+      diag("phaseA no-hash (early return)");
+      return;
+    }
     callbackHandledRef.current = true;
     clearHash();
 
     const claimNonce = peekIdTokenNonce(parsed.idToken);
+    diag(
+      `phaseA compare claim=${claimNonce ?? "<null>"} state.nonce=${nonce} storage.nonce=${sessionStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"}`,
+    );
     if (claimNonce !== nonce) {
       // Twitch のキャッシュ問題で stale nonce の id_token が返されることがある
       // (前タブで login 成功 → タブ close → 新タブで login すると再現)。ユーザが


### PR DESCRIPTION
## Summary

PR #95 で `claimed/expected` を warn に含めたが、mismatch 検知時点では storage が既に rewrite 済みのため、ユーザの仮説 (「Mount 2 の ensureNonce が storage 空を見て新規発行している」) を検証できない。

ensureNonce / rotateNonce / Phase A の各イベント発火時に \`[auth]\` prefix 付き console.log を出し、"Preserve log upon navigation" 有効状態で時系列を追えるようにする。

## 想定ログ出力

### 正常系 (Mount 1 → Mount 2 で storage 保たれた場合)

\`\`\`
[auth] ensureNonce read=<null> generated=25f085d5...      ← Mount 1
[auth] phaseA enter hash=<empty> state.nonce=25f085d5 storage.nonce=25f085d5 ...
[auth] phaseA no-hash (early return)
(ユーザクリック → Twitch → 戻り)
[auth] ensureNonce read=25f085d5 (no gen)                 ← Mount 2 で storage 保たれた
[auth] phaseA enter hash=present state.nonce=25f085d5 storage.nonce=25f085d5 ...
[auth] phaseA compare claim=25f085d5 state.nonce=25f085d5 storage.nonce=25f085d5
[auth] rotateNonce before=25f085d5 after=<new>
\`\`\`

### 仮説どおり (Mount 2 の storage が空の場合)

\`\`\`
[auth] ensureNonce read=<null> generated=25f085d5...      ← Mount 1
(ユーザクリック → Twitch → 戻り)
[auth] ensureNonce read=<null> generated=535a9b1c...      ← ★ Mount 2 で再発行
[auth] phaseA enter ... state.nonce=535a9b1c storage.nonce=535a9b1c ...
[auth] phaseA compare claim=25f085d5 state.nonce=535a9b1c storage.nonce=535a9b1c
id_token nonce mismatch; auto-retrying (1/2) claimed=25f085d5 expected=535a9b1c
\`\`\`

★ の行が出れば「Mount 2 の ensureNonce が storage 空を見て新規発行」が確定。これは:
- 別タブで callback が着地した (middle-click 等で新タブ化)
- storage が途中で何かに消された
- Mount 1 での setItem 自体が効いていない

のいずれかを示唆する。

## 変更内容

- \`ensureNonce\`: read した値 / 新規生成したかを log
- \`rotateNonce\`: before / after を log
- Phase A: enter 時と compare 時に state.nonce / storage.nonce / claim / hash 有無を log

挙動変更なし (log 追加のみ)。既存 245 テスト無修正で pass。

## Test plan

- [x] type / lint / unit test pass
- [ ] deploy 後、ユーザに "Preserve log upon navigation" ON で mismatch を再現してもらい、\`[auth]\` 行を全部共有してもらう

🤖 Generated with [Claude Code](https://claude.com/claude-code)