### PR TITLE
refactor(client): template import の error ハンドリングで `as Error` キャストを排除

### DIFF
--- a/client/src/hooks/useTemplateOperations.ts
+++ b/client/src/hooks/useTemplateOperations.ts
@@ -140,7 +140,7 @@ export const useTemplateOperations = ({
         type: "error",
         title: t("error.template.import.title"),
         message: t("error.template.import.message", {
-          error: (error as Error).message,
+          error: error instanceof Error ? error.message : String(error),
         }),
         autoClose: true,
       });


### PR DESCRIPTION
## Summary

`client/src/hooks/useTemplateOperations.ts` の `onImportTemplates` catch 節で、`(error as Error).message` と書かれていた unsafe なキャストを `error instanceof Error ? error.message : String(error)` に置換する。

## 背景

TypeScript の `catch (error)` で拾う値は `unknown` 型であり、`Error` のサブクラスとは限らない (文字列や任意の値を `throw` される可能性がある)。ここで `as Error` を使うと型チェックを騙すだけで、非 `Error` 値を受けたときに `.message` が `undefined` になり、i18n テンプレートに `undefined` が埋め込まれて notification が壊れる。

`importTemplates()` は `new Error(...)` しか投げないため実害は出ていなかったが、将来の変更で他の値が混入すると silent に壊れるため、narrowing を入れて型情報をそのまま活かす。

## 変更内容

- `client/src/hooks/useTemplateOperations.ts:143` — `(error as Error).message` → `error instanceof Error ? error.message : String(error)`

## 補足 (検討したがやらなかったこと)

- `client/` 配下を grep した結果、同形の `as Error` キャストは本箇所のみ。`utils/error.ts` 等に共通化するほどの重複ではないため inline で対応した
- 他の catch ブロック (`useStorage.ts` / `templateIO.ts` / `tRpcSyncProvider.ts`) は error オブジェクトのプロパティを参照しないため変更不要

## Test plan

- [x] `bun run check:type` (全ワークスペース pass)
- [x] `bun run check:lint` (全ワークスペース pass)
- [x] `bun run check:test` (245 pass / 0 fail)
- [ ] 手動: 壊れた JSON をインポートして error notification に parse error メッセージが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)