### PR TITLE
chore(client): nonce mismatch 調査のため storage / navigation 環境を diag に追加

### DIFF
--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -32,6 +32,9 @@ const NONCE_STORAGE_KEY = "oauth_nonce";
 const RETRY_COUNT_STORAGE_KEY = "oauth_retry_count";
 const MAX_AUTO_RETRIES = 2;
 
+/** 診断用: localStorage 側に Mount 1 の時刻を置いて、Mount 2 で読めるか確認する */
+const WITNESS_STORAGE_KEY = "oauth_witness_ts";
+
 /**
  * 診断ログ。nonce mismatch の真因調査用に ensureNonce / rotateNonce /
  * Phase A の各イベント発火時点で console.log する。mismatch 検知時点では
@@ -46,19 +49,84 @@ function diag(msg: string): void {
 }
 
 /**
+ * sessionStorage の全 key を summary にする。どの key が生き残っている (or 消えた)
+ * かで wholesale clear か selective clear か判別できる。
+ */
+function dumpSessionKeys(): string {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const k = sessionStorage.key(i);
+      if (k) keys.push(k);
+    }
+    return keys.length === 0 ? "<empty>" : `[${keys.join(", ")}]`;
+  } catch {
+    return "<error>";
+  }
+}
+
+/**
+ * localStorage 側に witness (timestamp) を置く & 読む。sessionStorage だけが
+ * 特殊に消えたのか、全ブラウジング context ごと別物になったのかを区別する。
+ */
+function readWitness(): string | null {
+  try {
+    return localStorage.getItem(WITNESS_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+function writeWitness(): void {
+  try {
+    localStorage.setItem(WITNESS_STORAGE_KEY, new Date().toISOString());
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * navigation の性質を dump。type は "navigate" / "reload" / "back_forward" /
+ * "prerender" のいずれか。referrer も一緒に取る。
+ */
+function dumpEnvironment(): string {
+  const ref = document.referrer || "<empty>";
+  const winName = window.name || "<empty>";
+  let navType = "<unknown>";
+  try {
+    const nav = performance.getEntriesByType("navigation")[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    navType = nav?.type ?? "<none>";
+  } catch {
+    /* ignore */
+  }
+  return `referrer=${ref} winName=${winName} navType=${navType}`;
+}
+
+/**
  * mount 時点で sessionStorage に nonce が無ければ同期的に発行する。
  * useState の lazy init は first render の前に走るため、authorize URL を組み
  * 立てる時点で必ず sessionStorage に nonce が居る状態が保証される。
  */
 function ensureNonce(): string {
   const existing = sessionStorage.getItem(NONCE_STORAGE_KEY);
+  // mount 毎に一度だけ環境情報をダンプ (ensureNonce は Mount ごとに 1 度だけ呼ばれる)
+  diag(
+    `env ${dumpEnvironment()} sessionKeys=${dumpSessionKeys()} witness=${readWitness() ?? "<null>"}`,
+  );
   if (existing) {
     diag(`ensureNonce read=${existing} (no gen)`);
+    writeWitness();
     return existing;
   }
   const fresh = generateNonce();
   sessionStorage.setItem(NONCE_STORAGE_KEY, fresh);
-  diag(`ensureNonce read=<null> generated=${fresh}`);
+  // 書込が即座に見えるか検証 (storage engine のバグや quota exceeded を検出)
+  const verify = sessionStorage.getItem(NONCE_STORAGE_KEY);
+  diag(
+    `ensureNonce read=<null> generated=${fresh} postWriteRead=${verify ?? "<null>"}`,
+  );
+  writeWitness();
   return fresh;
 }
 


### PR DESCRIPTION
## Summary

PR #96 で「Mount 2 の ensureNonce が storage 空を見て新規発行している」ことが判明したが、ユーザが **同じタブで操作した** ことを確言しているため、別タブ仮説は成立しない。sessionStorage が同一タブ内で消える原因を絞り込むため、環境情報を dump する。

## 追加する log

mount 毎 (ensureNonce 時) に 1 行:

\`\`\`
[auth] env referrer=<url> winName=<name> navType=<type> sessionKeys=[...] witness=<timestamp|null>
\`\`\`

ensureNonce の書込路線で 1 行:

\`\`\`
[auth] ensureNonce read=<null> generated=<uuid> postWriteRead=<uuid>
\`\`\`

## 注目ポイント

Mount 2 の env 行で以下を確認:

| 観測 | 示唆 |
|---|---|
| `sessionKeys=<empty>` | **wholesale clear** (Clear-Site-Data / privacy extension / 全消去) |
| `sessionKeys=[twitch-auth, ...]` で oauth_nonce だけ欠落 | **selective clear** (我々のコードが removeItem してる) |
| `witness=<timestamp>` かつ sessionKeys が別物 | **別 browsing context だが localStorage は共有** (partitioned storage や複数 window 等) |
| `witness=<null>` | **別ブラウザ session** (別タブ or 別ブラウザインスタンス) |
| `referrer=https://id.twitch.tv/...` | Twitch 経由で戻ってきた (想定通り) |
| `referrer=<empty>` or 別 | 途中で何らかの中継が入った |
| `navType=back_forward` | bfcache 復帰 (sessionStorage が期待値を持っていない可能性あり) |
| `postWriteRead=<null>` | **setItem が効いていない** (quota 等) |

これで絞り込んで次の修正に移ります。

## Test plan

- [x] type / lint / unit test pass (245 pass, 0 fail)
- [ ] deploy 後、再度ユーザに再現してもらい env 行を共有

🤖 Generated with [Claude Code](https://claude.com/claude-code)