### PR TITLE
fix(server): COOP: same-origin を disable して OAuth redirect の sessionStorage 消失を解消

### DIFF
--- a/server/src/presentation/index.ts
+++ b/server/src/presentation/index.ts
@@ -24,6 +24,19 @@ export function createApp(ctx: Context) {
       xContentTypeOptions: "nosniff",
       xXssProtection: "1; mode=block",
       referrerPolicy: "strict-origin-when-cross-origin",
+      // Hono の secureHeaders はデフォルトで Cross-Origin-Opener-Policy:
+      // same-origin を送る。これが有効だと OAuth implicit flow の cross-origin
+      // redirect (tags → id.twitch.tv → tags) で browsing context group が
+      // 切り替わり、同じタブでも sessionStorage が wholesale クリアされる挙動
+      // になる。nonce の sessionStorage 保管が callback 着地時に失われ、
+      // 「nonce mismatch で初回ログイン失敗 → 2 度ログイン必要」という症状に
+      // なっていた。
+      //
+      // 本ツールの脅威モデル (個人配信者 1 ユーザ、機密クロスオリジン資源なし) では
+      // COOP による Spectre 緩和の便益が薄いため disable する。必要なら他の
+      // header (X-Frame-Options / CSP frame-ancestors) で iframe 禁止、
+      // `origin-agent-cluster: ?1` でメモリ隔離を別途担保する。
+      crossOriginOpenerPolicy: false,
       contentSecurityPolicy: {
         defaultSrc: ["'self'"],
         // Cloudflare proxy 経由 (本番) では Cloudflare Insights の beacon.min.js が


### PR DESCRIPTION
## Summary

**真犯人確定**: Hono の \`secureHeaders()\` が default で送っていた \`Cross-Origin-Opener-Policy: same-origin\` が、OAuth implicit flow の cross-origin redirect を跨いだ sessionStorage 永続性を壊していました。

\`crossOriginOpenerPolicy: false\` で header を明示的に disable することで修正します。

## 原因特定までの経緯

| PR | 観測 |
|---|---|
| #89 | 初回 login で Bearer race と推測 → sessionStorage 直読みに修正 (残るバグ) |
| #91 | stale id_token race と推測 → cancel+reset に修正 (残るバグ) |
| #93 | network error で Phase B 誤発動と推測 → HTTP 401 限定に (close, 本事象無関係) |
| #94 | Twitch の id_token cache と推測 → auto-retry 導入 (対症療法) |
| #95 | mismatch log に nonce 値を追加 |
| #96 | ensureNonce / rotateNonce / Phase A に診断 log |
| #98 | env (referrer/navType/sessionKeys/localStorage witness) 追加 |
| **本 PR** | **診断結果から真犯人 = COOP 特定、root cause fix** |

PR #98 のログで以下が観測されました:

\`\`\`
Mount 1:
  env ... sessionKeys=<empty> witness=<prior ts>
  ensureNonce read=<null> generated=N1 postWriteRead=N1
(ナビゲーション: tags → id.twitch.tv → tags, ユーザ報告では同じタブ)
Mount 2:
  env referrer=tags.yuniruyuni.net sessionKeys=<empty> witness=<recent ts>
  ensureNonce read=<null> generated=N2  ← storage 空、witness は生存
phaseA compare claim=N1 state.nonce=N2 → mismatch
\`\`\`

**localStorage は保持されているのに sessionStorage が全 key 消失** = browsing context group 切替 = COOP の挙動、と確定しました。

## 修正内容

\`\`\`ts
secureHeaders({
  // ... 既存設定
  crossOriginOpenerPolicy: false,   // header を送らない
})
\`\`\`

### Security 面の検討

本ツールの脅威モデル:
- 個人配信者 1 ユーザ (マルチテナント無し)
- 機密クロスオリジン資源を扱わない
- Spectre 系攻撃の便益は薄い

引き続き担保される防御:
- iframe 禁止: \`X-Frame-Options: SAMEORIGIN\` + CSP \`frame-ancestors 'none'\`
- メモリ隔離: \`origin-agent-cluster: ?1\` (Hono default)
- CSRF: CSP + SameSite Cookie (ADR 0007 以降は sessionStorage ベースの Bearer)

COOP 無効化のトレードオフは受容可能と判断。

## 期待される効果

deploy 後、「1 度 login → タブ閉じ → 新タブで再 login」が **1 クリックで完結** するはずです。

- \`[auth] ensureNonce read=<existing_nonce> (no gen)\` が Mount 2 で出る (storage 保持確認)
- \`[auth] phaseA compare claim=X state.nonce=X\` が一致 (auto-retry 発動せず)

## Follow-up (別 PR)

COOP 修正が効いたら、以下は不要になるので削除する:

- PR #94 の auto-retry + retry_count (対症療法だった)
- PR #96/#98 の大量の console.log 診断 (診断用)
- localStorage witness

本 PR が効くことをユーザに確認してもらってから clean up する。

## Test plan

- [x] server check:type / check:lint / check:test pass
- [ ] deploy 後、ユーザに「1 度 login → タブ閉じ → 新タブ login」を試してもらい、1 クリックで MainScreen に到達することを確認
- [ ] \`[auth]\` console log で Mount 2 が \`ensureNonce read=<existing>\` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)