### PR TITLE
fix(client): nonce を localStorage 保管にして OAuth redirect で消える問題を解消

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -134,11 +134,14 @@ function renderWithProvider(
 const BASE_URL = "http://localhost:3000/";
 beforeEach(() => {
   sessionStorage.clear();
+  // nonce は localStorage 保管のためこちらもクリア
+  localStorage.clear();
   window.location.href = BASE_URL;
 });
 
 afterEach(() => {
   sessionStorage.clear();
+  localStorage.clear();
   window.location.href = BASE_URL;
 });
 
@@ -157,7 +160,7 @@ test("fresh visitor sees Entrance (no tokens, no hash)", async () => {
 test("fresh login: Entrance → Twitch callback (matching nonce) → AUTHENTICATED", async () => {
   const nonce = "fresh-nonce";
   const idToken = fakeJwt({ nonce, sub: "u1" });
-  sessionStorage.setItem("oauth_nonce", nonce);
+  localStorage.setItem("oauth_nonce", nonce);
   window.location.hash = `#access_token=at&id_token=${idToken}&token_type=bearer&expires_in=14400`;
 
   const { findByText, queryByText, calls } = renderWithProvider((bearer) =>
@@ -207,7 +210,7 @@ test("stale id_token + callback hash で 2 度ログイン不要 (regression, PR
 
   sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(oldIdToken));
   sessionStorage.setItem("twitch-auth", JSON.stringify("old-access"));
-  sessionStorage.setItem("oauth_nonce", newNonce);
+  localStorage.setItem("oauth_nonce", newNonce);
   window.location.hash = `#access_token=new-access&id_token=${newIdToken}&token_type=bearer&expires_in=14400`;
 
   const { findByText, queryByText, calls } = renderWithProvider((bearer) =>
@@ -242,7 +245,7 @@ test("session expired (valid token in storage but server 401): Phase B cleans up
   expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
   expect(sessionStorage.getItem("twitch-auth")).toBeNull();
   // nonce は新しいものに rotate されている (= Entrance の authorize URL は fresh)
-  expect(sessionStorage.getItem("oauth_nonce")).not.toBeNull();
+  expect(localStorage.getItem("oauth_nonce")).not.toBeNull();
 });
 
 // =============================================================================
@@ -254,7 +257,7 @@ test("nonce mismatch in callback id_token → auto-retry by navigating to author
   // しても stale な nonce claim の id_token を返すケース。手で 2 度 login ボタンを
   // 押せば成功するが UX が悪い。mismatch 検出時に client 側で自動的に再 authorize
   // することで 1 クリックで login 完了させる。
-  sessionStorage.setItem("oauth_nonce", "expected-nonce");
+  localStorage.setItem("oauth_nonce", "expected-nonce");
   const bogusIdToken = fakeJwt({ nonce: "stale-nonce", sub: "u1" });
   window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer&expires_in=14400`;
   const originalHref = window.location.href;
@@ -275,7 +278,7 @@ test("nonce mismatch in callback id_token → auto-retry by navigating to author
   expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
   expect(sessionStorage.getItem("twitch-auth")).toBeNull();
   // nonce は rotate 済 (次の authorize は fresh な値で走る)
-  expect(sessionStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
+  expect(localStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
   // auto-retry 用のカウンタが sessionStorage に立つ
   expect(sessionStorage.getItem("oauth_retry_count")).toBe("1");
 });
@@ -283,7 +286,7 @@ test("nonce mismatch in callback id_token → auto-retry by navigating to author
 test("nonce mismatch が連続した場合、MAX_AUTO_RETRIES で auto-retry を停止して Entrance を出す", async () => {
   // 攻撃者が執拗に stale token を inject し続ける or Twitch が壊れてる等で
   // 無限 retry loop を避けるガード。
-  sessionStorage.setItem("oauth_nonce", "expected");
+  localStorage.setItem("oauth_nonce", "expected");
   sessionStorage.setItem("oauth_retry_count", "2"); // 既に MAX 到達
   const bogusIdToken = fakeJwt({ nonce: "stale", sub: "u1" });
   window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer`;
@@ -308,7 +311,7 @@ test("nonce が一致して login 成功した場合、oauth_retry_count はク�
   // リセットされ、次回 login は fresh な状態から始まる。
   const nonce = "match";
   const idToken = fakeJwt({ nonce, sub: "u1" });
-  sessionStorage.setItem("oauth_nonce", nonce);
+  localStorage.setItem("oauth_nonce", nonce);
   sessionStorage.setItem("oauth_retry_count", "1");
   window.location.hash = `#access_token=at&id_token=${idToken}&token_type=bearer`;
 
@@ -325,7 +328,7 @@ test("nonce が一致して login 成功した場合、oauth_retry_count はク�
 });
 
 test("malformed id_token (can't parse nonce) → Entrance (no tokens saved)", async () => {
-  sessionStorage.setItem("oauth_nonce", "n1");
+  localStorage.setItem("oauth_nonce", "n1");
   // peekIdTokenNonce が null を返す形式
   const badIdToken = "not-a-jwt";
   window.location.hash = `#access_token=at&id_token=${badIdToken}&token_type=bearer&expires_in=14400`;
@@ -340,7 +343,7 @@ test("malformed id_token (can't parse nonce) → Entrance (no tokens saved)", as
 });
 
 test("hash present but missing id_token (Twitch protocol error) → Entrance, tokens not touched", async () => {
-  sessionStorage.setItem("oauth_nonce", "n1");
+  localStorage.setItem("oauth_nonce", "n1");
   // access_token のみ、id_token 無し → parseAuthFromHash は null を返す
   window.location.hash = `#access_token=at&token_type=bearer&expires_in=14400`;
 
@@ -353,11 +356,11 @@ test("hash present but missing id_token (Twitch protocol error) → Entrance, to
   expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
   expect(sessionStorage.getItem("twitch-auth")).toBeNull();
   // nonce は保持される (callback が成立していないので消費しない)
-  expect(sessionStorage.getItem("oauth_nonce")).toBe("n1");
+  expect(localStorage.getItem("oauth_nonce")).toBe("n1");
 });
 
 test("hash present but missing access_token → Entrance, tokens not touched", async () => {
-  sessionStorage.setItem("oauth_nonce", "n1");
+  localStorage.setItem("oauth_nonce", "n1");
   const idToken = fakeJwt({ nonce: "n1", sub: "u1" });
   // id_token のみ、access_token 無し → parseAuthFromHash は null を返す
   window.location.hash = `#id_token=${idToken}&token_type=bearer`;
@@ -392,7 +395,7 @@ test("logout clears tokens, rotates nonce, and returns to Entrance", async () =>
   const idToken = fakeJwt({ nonce: "n1", sub: "u1" });
   sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(idToken));
   sessionStorage.setItem("twitch-auth", JSON.stringify("at"));
-  sessionStorage.setItem("oauth_nonce", "n1");
+  localStorage.setItem("oauth_nonce", "n1");
 
   const { findByText, getByRole } = renderWithProvider(
     (bearer) =>
@@ -419,7 +422,7 @@ test("logout clears tokens, rotates nonce, and returns to Entrance", async () =>
   );
   expect(sessionStorage.getItem("twitch-auth")).toBeNull();
   // nonce は新 nonce に rotate されている
-  const newNonce = sessionStorage.getItem("oauth_nonce");
+  const newNonce = localStorage.getItem("oauth_nonce");
   expect(newNonce).not.toBeNull();
   expect(newNonce).not.toBe("n1");
   expect(await findByText("ENTRANCE")).toBeInTheDocument();
@@ -438,7 +441,7 @@ test("in-flight stale meQuery が 401 を返しても、Phase A 後の reset で
   const newIdToken = fakeJwt({ nonce: newNonce, sub: "u1" });
 
   sessionStorage.setItem(ID_TOKEN_STORAGE_KEY, JSON.stringify(oldIdToken));
-  sessionStorage.setItem("oauth_nonce", newNonce);
+  localStorage.setItem("oauth_nonce", newNonce);
   window.location.hash = `#access_token=at&id_token=${newIdToken}&token_type=bearer`;
 
   const { findByText, calls } = renderWithProvider((bearer) =>

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -22,7 +22,22 @@ import {
   peekIdTokenNonce,
 } from "./utils";
 
-/** nonce を Twitch redirect 往復の間に保管する sessionStorage key */
+/**
+ * nonce を Twitch redirect 往復の間に保管する localStorage key。
+ *
+ * **なぜ localStorage か**: サーバが `Cross-Origin-Opener-Policy: same-origin`
+ * を送っているため、OAuth implicit flow の cross-origin redirect
+ * (tags → id.twitch.tv → tags) で browsing context group が切り替わり、同じ
+ * タブでも sessionStorage が wholesale クリアされる (Chrome 実測)。nonce が
+ * callback 着地時に失われて「nonce mismatch で 2 度ログイン要求」の症状に
+ * なっていた。localStorage は origin 単位で永続化するため browsing context
+ * group の切替に影響されず保持される。
+ *
+ * **security 上の trade-off**: localStorage は tab 間共有になるが、nonce は
+ * authorize URL に平文で載る公開情報で秘匿性は要求されないため影響なし。
+ * mix-up 攻撃耐性は被害者独自の storage 値と claim の照合で担保される
+ * (URL state 方式と違い、攻撃者が一方的にセットできる値ではない)。
+ */
 const NONCE_STORAGE_KEY = "oauth_nonce";
 /**
  * nonce mismatch 時に auto-retry した回数を保持する sessionStorage key。
@@ -104,12 +119,12 @@ function dumpEnvironment(): string {
 }
 
 /**
- * mount 時点で sessionStorage に nonce が無ければ同期的に発行する。
+ * mount 時点で localStorage に nonce が無ければ同期的に発行する。
  * useState の lazy init は first render の前に走るため、authorize URL を組み
- * 立てる時点で必ず sessionStorage に nonce が居る状態が保証される。
+ * 立てる時点で必ず localStorage に nonce が居る状態が保証される。
  */
 function ensureNonce(): string {
-  const existing = sessionStorage.getItem(NONCE_STORAGE_KEY);
+  const existing = localStorage.getItem(NONCE_STORAGE_KEY);
   // mount 毎に一度だけ環境情報をダンプ (ensureNonce は Mount ごとに 1 度だけ呼ばれる)
   diag(
     `env ${dumpEnvironment()} sessionKeys=${dumpSessionKeys()} witness=${readWitness() ?? "<null>"}`,
@@ -120,9 +135,9 @@ function ensureNonce(): string {
     return existing;
   }
   const fresh = generateNonce();
-  sessionStorage.setItem(NONCE_STORAGE_KEY, fresh);
+  localStorage.setItem(NONCE_STORAGE_KEY, fresh);
   // 書込が即座に見えるか検証 (storage engine のバグや quota exceeded を検出)
-  const verify = sessionStorage.getItem(NONCE_STORAGE_KEY);
+  const verify = localStorage.getItem(NONCE_STORAGE_KEY);
   diag(
     `ensureNonce read=<null> generated=${fresh} postWriteRead=${verify ?? "<null>"}`,
   );
@@ -180,13 +195,13 @@ export const TwitchAuthProvider: FC<Props> = ({
 
   /**
    * 現 nonce を消費し、次回ログイン用に新しい nonce を発行する。
-   * sessionStorage と React state の両方を同期的に更新する。
+   * localStorage と React state の両方を同期的に更新する。
    */
   const rotateNonce = useCallback(() => {
-    const before = sessionStorage.getItem(NONCE_STORAGE_KEY);
-    sessionStorage.removeItem(NONCE_STORAGE_KEY);
+    const before = localStorage.getItem(NONCE_STORAGE_KEY);
+    localStorage.removeItem(NONCE_STORAGE_KEY);
     const fresh = generateNonce();
-    sessionStorage.setItem(NONCE_STORAGE_KEY, fresh);
+    localStorage.setItem(NONCE_STORAGE_KEY, fresh);
     setNonce(fresh);
     diag(`rotateNonce before=${before ?? "<null>"} after=${fresh}`);
   }, []);
@@ -197,7 +212,7 @@ export const TwitchAuthProvider: FC<Props> = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on mount
   useEffect(() => {
     diag(
-      `phaseA enter hash=${window.location.hash ? "present" : "<empty>"} state.nonce=${nonce} storage.nonce=${sessionStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"} callbackHandled=${callbackHandledRef.current}`,
+      `phaseA enter hash=${window.location.hash ? "present" : "<empty>"} state.nonce=${nonce} storage.nonce=${localStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"} callbackHandled=${callbackHandledRef.current}`,
     );
     if (callbackHandledRef.current) return;
     const parsed = parseAuthFromHash();
@@ -210,7 +225,7 @@ export const TwitchAuthProvider: FC<Props> = ({
 
     const claimNonce = peekIdTokenNonce(parsed.idToken);
     diag(
-      `phaseA compare claim=${claimNonce ?? "<null>"} state.nonce=${nonce} storage.nonce=${sessionStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"}`,
+      `phaseA compare claim=${claimNonce ?? "<null>"} state.nonce=${nonce} storage.nonce=${localStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"}`,
     );
     if (claimNonce !== nonce) {
       // Twitch のキャッシュ問題で stale nonce の id_token が返されることがある
@@ -246,7 +261,7 @@ export const TwitchAuthProvider: FC<Props> = ({
       sessionStorage.setItem(RETRY_COUNT_STORAGE_KEY, String(retryCount + 1));
       rotateNonce();
       const freshNonce =
-        sessionStorage.getItem(NONCE_STORAGE_KEY) ?? generateNonce();
+        localStorage.getItem(NONCE_STORAGE_KEY) ?? generateNonce();
       const provider = getAuthProvider({
         get: () => idToken,
         set: setIdToken,


### PR DESCRIPTION
## Summary

真犯人確定: サーバの `Cross-Origin-Opener-Policy: same-origin` ヘッダ (Hono secureHeaders のデフォルト) が、OAuth redirect で browsing context group の切替を引き起こし、同じタブでも sessionStorage を wholesale クリアしていた。

nonce 保管を `sessionStorage` → `localStorage` に変えることで解消する。

## PR #99 (COOP 削除) ではなくこちらを採用した理由

| | COOP 削除 (#99) | localStorage (本PR) |
|---|---|---|
| Spectre 攻撃緩和 | 🔻 消失 (Site Isolation のみに依存) | ✅ 維持 |
| Tabnabbing 防御 | 🔻 消失 (window.opener 切断不可) | ✅ 維持 |
| Mix-up 攻撃耐性 | ✅ 現状維持 | ✅ 現状維持 |
| 差分サイズ | 1 行 | 数行 |

本 app には `window.open("https://x.com/intent/tweet", "_blank")` (noopener 無し) など tabnabbing ベクタが実在するため、COOP は維持すべき。localStorage は PR #98 の診断ログで COOP の browsing context 切替を跨いで保持されることが実証済み。

## 修正内容

- `ensureNonce` / `rotateNonce` / Phase A 内の nonce 参照を `sessionStorage` → `localStorage`
- `oauth_nonce` key のみ。`twitch-auth` / `twitch-id-token` / `oauth_retry_count` は sessionStorage のまま (tab 単位のライフサイクルが適切)
- test を localStorage 参照に更新、`beforeEach`/`afterEach` で `localStorage.clear()` 追加

## Security 分析

**nonce を localStorage に置く影響**:
- **tab 間共有**: nonce は authorize URL に平文で載る公開情報。秘匿性要求なし。並行 login では rotate で value が揺れうるが各 flow 独立に match 成立するので実害なし
- **tab close 後の残存**: 次回起動時に既存値を再利用。attacker には未知のランダム UUID なので攻撃に使えない
- **XSS 耐性**: sessionStorage でも localStorage でも同じ (どちらも XSS で読める)

**mix-up 攻撃耐性**: 攻撃者が自前の `id_token(nonce=X)` を被害者に注入しても、被害者の localStorage には自分で生成した `nonce=V` が入っているため claim=X vs state=V で mismatch になる。**URL state 方式と違い、攻撃者が一方的にセットできる値ではない**ので現状の security は維持される。

## Test plan

- [x] type / lint / unit test pass (245 pass, 0 fail)
- [ ] deploy 後、「1 度 login → タブ閉じ → 新タブ login」が 1 クリックで通ることを確認
- [ ] `[auth]` ログで Mount 2 が `ensureNonce read=<existing>` になっていることを確認

## Follow-up

本 PR の効果確認後、別 PR で:
- PR #94 の auto-retry + retry_count (対症療法だったので不要に)
- PR #96 / #98 の診断 log (diag / witness / dumpSessionKeys / dumpEnvironment)
- `window.open("https://x.com/...", "_blank", "noopener")` 追加 (defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)