### PR TITLE
security(client): window.open の X 投稿に noopener,noreferrer を追加

### DIFF
--- a/client/src/TemplateCard/TemplateActions/component.tsx
+++ b/client/src/TemplateCard/TemplateActions/component.tsx
@@ -53,7 +53,14 @@ export const TemplateActions: React.FC<Props> = ({
                   url: `https://twitch.tv/${userLogin}`,
                 },
               );
-              window.open(buildTweetIntentUrl(text), "_blank");
+              // noopener,noreferrer: opened window (x.com) から window.opener 経由で
+              // 本タブを phishing URL に navigation 書換される tabnabbing を防ぐ。
+              // `AuthorInfo` の <a target="_blank" rel="noopener noreferrer"> に合わせた防御。
+              window.open(
+                buildTweetIntentUrl(text),
+                "_blank",
+                "noopener,noreferrer",
+              );
             }}
           >
             <svg


### PR DESCRIPTION
## Summary

`TemplateActions` の X (Twitter) 投稿ボタンが \`window.open(url, "_blank")\` を feature 文字列なしで呼んでおり、tabnabbing 脆弱性があった。\`noopener,noreferrer\` を追加して閉じる。

## 背景

nonce の localStorage 化 (PR #100) で COOP:same-origin を維持する判断をしたが、その前提として「本 app は window.open 経由の tabnabbing ベクタを持っている」ことが判明していた。COOP だけに tabnabbing 防御を依存させるのは defense-in-depth 的に良くないので、\`window.open\` 自体にも \`noopener\` を付ける。

\`AuthorInfo\` の \`<a target="_blank" rel="noopener noreferrer">\` には既に noopener が付いているので、これと整合させる。

## 変更内容

\`\`\`tsx
// before
window.open(buildTweetIntentUrl(text), "_blank");

// after
window.open(buildTweetIntentUrl(text), "_blank", "noopener,noreferrer");
\`\`\`

## Test plan

- [x] type / lint / unit test pass (245 pass, 0 fail)
- [ ] deploy 後、X 投稿ボタンクリックで x.com が正常に新タブで開き、投稿フォームが機能することを確認 (noopener が機能を壊していないこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)