### PR TITLE
cleanup(client): 真因解消後に不要になった nonce 診断 log と auto-retry を削除

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -252,44 +252,12 @@ test("session expired (valid token in storage but server 401): Phase B cleans up
 // Nonce / callback validation
 // =============================================================================
 
-test("nonce mismatch in callback id_token → auto-retry by navigating to authorize URL (regression #93-follow-up)", async () => {
-  // Twitch が前セッションの id_token を cache して、新しい nonce で authorize
-  // しても stale な nonce claim の id_token を返すケース。手で 2 度 login ボタンを
-  // 押せば成功するが UX が悪い。mismatch 検出時に client 側で自動的に再 authorize
-  // することで 1 クリックで login 完了させる。
+test("nonce mismatch in callback id_token → Entrance (mix-up rejection, no tokens saved, nonce rotated)", async () => {
+  // localStorage.oauth_nonce と id_token claim.nonce が異なるケース = mix-up
+  // 攻撃 or 何らかの不整合。callback を破棄して Entrance に戻す。
   localStorage.setItem("oauth_nonce", "expected-nonce");
-  const bogusIdToken = fakeJwt({ nonce: "stale-nonce", sub: "u1" });
+  const bogusIdToken = fakeJwt({ nonce: "attacker-nonce", sub: "u1" });
   window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer&expires_in=14400`;
-  const originalHref = window.location.href;
-
-  renderWithProvider(() => ({ ok: true, data: { user: DEFAULT_USER } }));
-
-  await waitFor(
-    () => {
-      // Phase A が mismatch を検出して window.location.href を authorize URL に
-      // 向け直すことを確認
-      expect(window.location.href).not.toBe(originalHref);
-    },
-    { timeout: 1500 },
-  );
-  expect(window.location.href).toContain("id.twitch.tv/oauth2/authorize");
-
-  // token は保存されていない (stale token を拒否)
-  expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
-  expect(sessionStorage.getItem("twitch-auth")).toBeNull();
-  // nonce は rotate 済 (次の authorize は fresh な値で走る)
-  expect(localStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
-  // auto-retry 用のカウンタが sessionStorage に立つ
-  expect(sessionStorage.getItem("oauth_retry_count")).toBe("1");
-});
-
-test("nonce mismatch が連続した場合、MAX_AUTO_RETRIES で auto-retry を停止して Entrance を出す", async () => {
-  // 攻撃者が執拗に stale token を inject し続ける or Twitch が壊れてる等で
-  // 無限 retry loop を避けるガード。
-  localStorage.setItem("oauth_nonce", "expected");
-  sessionStorage.setItem("oauth_retry_count", "2"); // 既に MAX 到達
-  const bogusIdToken = fakeJwt({ nonce: "stale", sub: "u1" });
-  window.location.hash = `#access_token=at&id_token=${bogusIdToken}&token_type=bearer`;
 
   const { findByText } = renderWithProvider(() => ({
     ok: true,
@@ -297,34 +265,11 @@ test("nonce mismatch が連続した場合、MAX_AUTO_RETRIES で auto-retry を
   }));
 
   expect(await findByText("ENTRANCE")).toBeInTheDocument();
-  // retry 上限のため navigate はしない (href が id.twitch.tv/authorize 形式に
-  // なっていないこと、すなわち自 origin のままであることを確認)
-  expect(window.location.href).not.toContain("id.twitch.tv/oauth2/authorize");
-  // retry counter は reset される (次回の新規 login でまた 0 から数える)
-  expect(sessionStorage.getItem("oauth_retry_count")).toBeNull();
+  // token が保存されていない
   expect(sessionStorage.getItem(ID_TOKEN_STORAGE_KEY)).toBeNull();
-});
-
-test("nonce が一致して login 成功した場合、oauth_retry_count はクリアされる", async () => {
-  // auto-retry で 1 回目 mismatch → navigate → 2 回目 callback が一致して成功、
-  // というシーケンスの後半を模擬する。retry_count=1 の状態から成功すれば 0 に
-  // リセットされ、次回 login は fresh な状態から始まる。
-  const nonce = "match";
-  const idToken = fakeJwt({ nonce, sub: "u1" });
-  localStorage.setItem("oauth_nonce", nonce);
-  sessionStorage.setItem("oauth_retry_count", "1");
-  window.location.hash = `#access_token=at&id_token=${idToken}&token_type=bearer`;
-
-  const { findByText } = renderWithProvider((bearer) =>
-    bearer === idToken
-      ? { ok: true, data: { user: DEFAULT_USER } }
-      : { ok: false },
-  );
-
-  expect(
-    await findByText("AUTHENTICATED", {}, { timeout: 3000 }),
-  ).toBeInTheDocument();
-  expect(sessionStorage.getItem("oauth_retry_count")).toBeNull();
+  expect(sessionStorage.getItem("twitch-auth")).toBeNull();
+  // nonce は rotate 済 (攻撃用 nonce を再利用されない)
+  expect(localStorage.getItem("oauth_nonce")).not.toBe("expected-nonce");
 });
 
 test("malformed id_token (can't parse nonce) → Entrance (no tokens saved)", async () => {

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -39,84 +39,6 @@ import {
  * (URL state 方式と違い、攻撃者が一方的にセットできる値ではない)。
  */
 const NONCE_STORAGE_KEY = "oauth_nonce";
-/**
- * nonce mismatch 時に auto-retry した回数を保持する sessionStorage key。
- * Twitch が前 session の id_token を cache して stale nonce で返すバグの
- * 回避策として用いる。MAX を超えたら retry 停止して Entrance を出す。
- */
-const RETRY_COUNT_STORAGE_KEY = "oauth_retry_count";
-const MAX_AUTO_RETRIES = 2;
-
-/** 診断用: localStorage 側に Mount 1 の時刻を置いて、Mount 2 で読めるか確認する */
-const WITNESS_STORAGE_KEY = "oauth_witness_ts";
-
-/**
- * 診断ログ。nonce mismatch の真因調査用に ensureNonce / rotateNonce /
- * Phase A の各イベント発火時点で console.log する。mismatch 検知時点では
- * 既に storage が rewrite 済みのため、イベントが起きた瞬間に記録しないと
- * 真相が追えない。
- *
- * 再現時は DevTools Console の "Preserve log upon navigation" を ON にして
- * これらの行を時系列で追う。prefix `[auth]` で grep しやすくしてある。
- */
-function diag(msg: string): void {
-  console.log(`[auth] ${msg}`);
-}
-
-/**
- * sessionStorage の全 key を summary にする。どの key が生き残っている (or 消えた)
- * かで wholesale clear か selective clear か判別できる。
- */
-function dumpSessionKeys(): string {
-  try {
-    const keys: string[] = [];
-    for (let i = 0; i < sessionStorage.length; i++) {
-      const k = sessionStorage.key(i);
-      if (k) keys.push(k);
-    }
-    return keys.length === 0 ? "<empty>" : `[${keys.join(", ")}]`;
-  } catch {
-    return "<error>";
-  }
-}
-
-/**
- * localStorage 側に witness (timestamp) を置く & 読む。sessionStorage だけが
- * 特殊に消えたのか、全ブラウジング context ごと別物になったのかを区別する。
- */
-function readWitness(): string | null {
-  try {
-    return localStorage.getItem(WITNESS_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-function writeWitness(): void {
-  try {
-    localStorage.setItem(WITNESS_STORAGE_KEY, new Date().toISOString());
-  } catch {
-    /* ignore */
-  }
-}
-
-/**
- * navigation の性質を dump。type は "navigate" / "reload" / "back_forward" /
- * "prerender" のいずれか。referrer も一緒に取る。
- */
-function dumpEnvironment(): string {
-  const ref = document.referrer || "<empty>";
-  const winName = window.name || "<empty>";
-  let navType = "<unknown>";
-  try {
-    const nav = performance.getEntriesByType("navigation")[0] as
-      | PerformanceNavigationTiming
-      | undefined;
-    navType = nav?.type ?? "<none>";
-  } catch {
-    /* ignore */
-  }
-  return `referrer=${ref} winName=${winName} navType=${navType}`;
-}
 
 /**
  * mount 時点で localStorage に nonce が無ければ同期的に発行する。
@@ -125,23 +47,9 @@ function dumpEnvironment(): string {
  */
 function ensureNonce(): string {
   const existing = localStorage.getItem(NONCE_STORAGE_KEY);
-  // mount 毎に一度だけ環境情報をダンプ (ensureNonce は Mount ごとに 1 度だけ呼ばれる)
-  diag(
-    `env ${dumpEnvironment()} sessionKeys=${dumpSessionKeys()} witness=${readWitness() ?? "<null>"}`,
-  );
-  if (existing) {
-    diag(`ensureNonce read=${existing} (no gen)`);
-    writeWitness();
-    return existing;
-  }
+  if (existing) return existing;
   const fresh = generateNonce();
   localStorage.setItem(NONCE_STORAGE_KEY, fresh);
-  // 書込が即座に見えるか検証 (storage engine のバグや quota exceeded を検出)
-  const verify = localStorage.getItem(NONCE_STORAGE_KEY);
-  diag(
-    `ensureNonce read=<null> generated=${fresh} postWriteRead=${verify ?? "<null>"}`,
-  );
-  writeWitness();
   return fresh;
 }
 
@@ -198,12 +106,10 @@ export const TwitchAuthProvider: FC<Props> = ({
    * localStorage と React state の両方を同期的に更新する。
    */
   const rotateNonce = useCallback(() => {
-    const before = localStorage.getItem(NONCE_STORAGE_KEY);
     localStorage.removeItem(NONCE_STORAGE_KEY);
     const fresh = generateNonce();
     localStorage.setItem(NONCE_STORAGE_KEY, fresh);
     setNonce(fresh);
-    diag(`rotateNonce before=${before ?? "<null>"} after=${fresh}`);
   }, []);
 
   // Phase A (one-shot): Twitch callback の URL fragment を消費し、id_token と
@@ -211,72 +117,23 @@ export const TwitchAuthProvider: FC<Props> = ({
   // StrictMode の double-invoke もガード。
   // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on mount
   useEffect(() => {
-    diag(
-      `phaseA enter hash=${window.location.hash ? "present" : "<empty>"} state.nonce=${nonce} storage.nonce=${localStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"} callbackHandled=${callbackHandledRef.current}`,
-    );
     if (callbackHandledRef.current) return;
     const parsed = parseAuthFromHash();
-    if (!parsed) {
-      diag("phaseA no-hash (early return)");
-      return;
-    }
+    if (!parsed) return;
     callbackHandledRef.current = true;
     clearHash();
 
     const claimNonce = peekIdTokenNonce(parsed.idToken);
-    diag(
-      `phaseA compare claim=${claimNonce ?? "<null>"} state.nonce=${nonce} storage.nonce=${localStorage.getItem(NONCE_STORAGE_KEY) ?? "<null>"}`,
-    );
     if (claimNonce !== nonce) {
-      // Twitch のキャッシュ問題で stale nonce の id_token が返されることがある
-      // (前タブで login 成功 → タブ close → 新タブで login すると再現)。ユーザが
-      // もう一度 login ボタンを手動でクリックすれば成功するが UX が悪いので、
-      // mismatch を検出したら自動的に authorize URL へ再 navigate する。
-      //
-      // mix-up 攻撃の場合でも、再 navigate は Twitch が fresh token を返すだけ
-      // なので security 上のリスクは無い (stale token は破棄される)。
-      //
-      // ただし無限 retry ループを避けるため MAX_AUTO_RETRIES で打ち切り、
-      // 上限到達時は通常通り Entrance に戻してユーザの再操作を待つ。
-      const retryCount = Number(
-        sessionStorage.getItem(RETRY_COUNT_STORAGE_KEY) ?? "0",
-      );
-      // 根本原因 (Twitch の cache バグ vs URL encoding vs 別事象) の特定用に
-      // claim / expected の両値を出す。auto-retry の navigation で console が
-      // 消えるため、DevTools Console の "Preserve log upon navigation" を ON
-      // にしてから再現する。
-      const nonceDiag = `claimed=${claimNonce ?? "<null>"} expected=${nonce}`;
-      if (retryCount >= MAX_AUTO_RETRIES) {
-        console.warn(
-          `id_token nonce mismatch; auto-retry exhausted (${retryCount}/${MAX_AUTO_RETRIES}) ${nonceDiag}`,
-        );
-        sessionStorage.removeItem(RETRY_COUNT_STORAGE_KEY);
-        callbackHandledRef.current = false;
-        rotateNonce();
-        return;
-      }
-      console.warn(
-        `id_token nonce mismatch; auto-retrying (${retryCount + 1}/${MAX_AUTO_RETRIES}) ${nonceDiag}`,
-      );
-      sessionStorage.setItem(RETRY_COUNT_STORAGE_KEY, String(retryCount + 1));
+      // mix-up 攻撃 or sessionStorage が途中でクリアされた等。callback を破棄
+      // して新しい nonce で Entrance をやり直させる。
+      console.warn("id_token nonce mismatch; rejecting Twitch callback");
+      callbackHandledRef.current = false;
       rotateNonce();
-      const freshNonce =
-        localStorage.getItem(NONCE_STORAGE_KEY) ?? generateNonce();
-      const provider = getAuthProvider({
-        get: () => idToken,
-        set: setIdToken,
-        remove: removeIdToken,
-      });
-      window.location.href = provider.getEntranceUri(
-        `${APP_BASE_URL}/`,
-        scope,
-        freshNonce,
-      );
       return;
     }
 
-    // 一致 → consume + 次回用に新規発行 + retry counter を reset
-    sessionStorage.removeItem(RETRY_COUNT_STORAGE_KEY);
+    // 一致 → consume + 次回用に新規発行
     rotateNonce();
     setAccessToken(parsed.accessToken);
     setIdToken(parsed.idToken);


### PR DESCRIPTION
## Summary

PR #100 で nonce を localStorage に移して COOP 起因の sessionStorage 消失を根本解消した。以下は対症療法 / 診断ツールとして役目を終えたので削除する:

- **PR #94 の auto-retry + retry_count** (\`MAX_AUTO_RETRIES\` / \`RETRY_COUNT_STORAGE_KEY\` / mismatch 時の \`window.location.href = authorize_url\`)
- **PR #95 の console.warn 診断強化** (claim/expected 値付き)
- **PR #96 / #98 の diag() / dump* / witness** (\`[auth]\` console.log 群 + \`WITNESS_STORAGE_KEY\`)

## 差分規模

- \`provider.tsx\`: 157 行削除 (約 142 行純減)
- \`provider.test.tsx\`: auto-retry テスト 3 本削除、代わりに基本的な「nonce mismatch → Entrance」 test を 1 本追加 (mix-up 攻撃拒否の動作確認)
- 総 test 数: 245 → 243 (-2)

## Before / After (Phase A mismatch 経路)

**Before** (auto-retry 版):
\`\`\`ts
if (claimNonce !== nonce) {
  const retryCount = Number(sessionStorage.getItem(RETRY_COUNT_STORAGE_KEY) ?? "0");
  if (retryCount >= MAX_AUTO_RETRIES) {
    // 上限で Entrance に戻す
    ...
  }
  // auto-retry: rotateNonce + window.location.href = authorize_url
  ...
}
\`\`\`

**After** (PR #94 前と同じシンプル形):
\`\`\`ts
if (claimNonce !== nonce) {
  console.warn("id_token nonce mismatch; rejecting Twitch callback");
  callbackHandledRef.current = false;
  rotateNonce();
  return;
}
\`\`\`

nonce mismatch は真因 (COOP × sessionStorage) が解消されれば通常は起きない。残る mismatch は真の mix-up 攻撃 or 不整合なので、従来通り Entrance に戻してユーザの再操作を待つのが適切。

## Merge 順

この PR は **#100 の効果確認後** に merge 推奨。確認方法:

1. #100 deploy 後、「1 度ログイン → タブ閉じ → 新タブ再ログイン」を実施
2. \`[auth]\` console log で Mount 2 が \`ensureNonce read=<existing>\` になっている (storage 保持確認)
3. 1 クリックで MainScreen に到達

確認が取れたら本 PR を merge で log も消して本番コードを整理する。

## Test plan

- [x] type / lint / unit test pass (243 pass, 0 fail)
- [x] 「nonce mismatch → Entrance (mix-up rejection)」 test が pass
- [ ] #100 効果確認後に merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)