### PR TITLE
fix(client): ログイン完了後・reload 時の oauth_nonce 残留を解消

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -179,6 +179,9 @@ test("fresh login: Entrance → Twitch callback (matching nonce) → AUTHENTICAT
   );
   // hash が消費されていることも確認 (Phase A の clearHash)
   expect(window.location.hash).toBe("");
+  // login 成功後は nonce を localStorage から削除する (rotate ではなく consume)。
+  // 残すと他タブから見えるゴミになるだけで実用的な意味が無い。
+  expect(localStorage.getItem("oauth_nonce")).toBeNull();
 });
 
 test("returning visitor (valid id_token in storage, no hash) goes directly to AUTHENTICATED", async () => {

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -104,12 +104,27 @@ export const TwitchAuthProvider: FC<Props> = ({
   /**
    * 現 nonce を消費し、次回ログイン用に新しい nonce を発行する。
    * localStorage と React state の両方を同期的に更新する。
+   * 用途: mismatch で Entrance に戻す / logout / Phase B cleanup。
    */
   const rotateNonce = useCallback(() => {
     localStorage.removeItem(NONCE_STORAGE_KEY);
     const fresh = generateNonce();
     localStorage.setItem(NONCE_STORAGE_KEY, fresh);
     setNonce(fresh);
+  }, []);
+
+  /**
+   * login 成功時に nonce を localStorage から完全に削除する。
+   * ログイン後は authorize URL は再利用されない (idToken 有で useMemo が null
+   * を返すため) ので、storage に残しておく必要がない。次回 Entrance に戻った
+   * 時 (logout / Phase B / タブ再訪) は ensureNonce / rotateNonce が新規発行
+   * するので OK。
+   *
+   * React state は更新しない。idToken 有の間は authorizeUrl で読まれないし、
+   * 状態変化で不要な re-render を起こさないため。
+   */
+  const consumeNonce = useCallback(() => {
+    localStorage.removeItem(NONCE_STORAGE_KEY);
   }, []);
 
   // Phase A (one-shot): Twitch callback の URL fragment を消費し、id_token と
@@ -133,8 +148,9 @@ export const TwitchAuthProvider: FC<Props> = ({
       return;
     }
 
-    // 一致 → consume + 次回用に新規発行
-    rotateNonce();
+    // 一致 → storage から nonce を消費 (削除)。次回 login では ensureNonce が
+    // 新規発行するので storage に残しておく必要はない。
+    consumeNonce();
     setAccessToken(parsed.accessToken);
     setIdToken(parsed.idToken);
     // 前 session の stale id_token が storage に残っていた場合、mount 時に


### PR DESCRIPTION
## Summary

Twitch OAuth の nonce が意図しないタイミングで localStorage に残留していた 2 つの経路を塞ぐ:

1. **login 成功時に削除** — Phase A の nonce 一致経路で `rotateNonce` (削除 + 新規発行) を呼んでいたため、ログイン完了後も新しい nonce が残っていた。`consumeNonce` (削除のみ) に差し替え
2. **ログイン中の reload で発行しない** — `useState<string>(ensureNonce)` の lazy init が無条件に呼ばれていたため、既にログイン済みで reload しただけでも新しい nonce が書き込まれていた。idToken 有の場合は localStorage 既存値を state に積むだけで新規発行しない

どちらもログイン中は `authorizeUrl` の useMemo が `null` を返して nonce は参照されないため、書き込みは純粋にゴミを残すだけの挙動だった。

## Background

PR #100 で nonce を sessionStorage → localStorage に移行して「2 度ログイン」バグを解消した後、localStorage が永続化するストレージになったため、書き込みタイミングの雑さがゴミ残留として顕在化した。

logout / Phase B で Entrance に戻る経路では `rotateNonce` が新規発行するため、ログイン中に state / storage が `""` / null でも次の authorize URL 構築には支障なし。

## Test plan

- [x] `bun run check:type` pass
- [x] `bun run check:lint` pass
- [x] `bun test client/src/TwitchAuth/provider.test.tsx` — 11 pass (38 expect)
  - 新規 assertion 1: "fresh login" で login 成功後に `oauth_nonce` が null
  - 新規 assertion 2: "returning visitor" で reload 後に `oauth_nonce` が null
- [ ] 本番で login 後 / reload 後に DevTools Application → Local Storage に `oauth_nonce` が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)