### PR TITLE
fix(client): reload 時の無用な oauth_nonce 発行を抑制

### DIFF
--- a/client/src/TwitchAuth/provider.test.tsx
+++ b/client/src/TwitchAuth/provider.test.tsx
@@ -199,6 +199,10 @@ test("returning visitor (valid id_token in storage, no hash) goes directly to AU
     await findByText("AUTHENTICATED", {}, { timeout: 3000 }),
   ).toBeInTheDocument();
   expect(queryByText("ENTRANCE")).toBeNull();
+  // reload 時 (既にログイン中) は nonce を新規発行しない。ログイン中は
+  // authorize URL が null (idToken 有で useMemo が null を返す) なので nonce は
+  // 参照されず、発行すると localStorage にゴミが残るだけ。
+  expect(localStorage.getItem("oauth_nonce")).toBeNull();
 });
 
 // =============================================================================

--- a/client/src/TwitchAuth/provider.tsx
+++ b/client/src/TwitchAuth/provider.tsx
@@ -90,7 +90,15 @@ export const TwitchAuthProvider: FC<Props> = ({
     ID_TOKEN_STORAGE_KEY,
     "",
   );
-  const [nonce, setNonce] = useState<string>(ensureNonce);
+  // ログイン済 (idToken 有) では authorize URL の useMemo が null を返すため nonce
+  // は参照されない。ensureNonce を無条件に呼ぶと reload のたびに localStorage に
+  // 無用な nonce が書き込まれてしまうので、idToken 有の場合は既存値だけ state に
+  // 積み (stale-id_token + callback regression で Phase A が使う)、無ければ "" で
+  // 済ませる。logout / Phase B で Entrance に戻る時は rotateNonce が新規発行する。
+  const [nonce, setNonce] = useState<string>(() => {
+    if (idToken) return localStorage.getItem(NONCE_STORAGE_KEY) ?? "";
+    return ensureNonce();
+  });
   const callbackHandledRef = useRef(false);
   const queryClient = useQueryClient();
   const utils = trpc.useUtils();


### PR DESCRIPTION
## Summary

ログイン済のユーザーが reload しただけで localStorage に `oauth_nonce` が書き込まれていた問題を修正する。

`useState<string>(ensureNonce)` の lazy init が無条件に `ensureNonce` を呼んでいたため、既に idToken が sessionStorage に入っている状態でも reload 時に nonce が新規発行されていた。ログイン中は `authorizeUrl` の useMemo が `null` を返して nonce は参照されないため、書き込みは純粋にゴミを残すだけの挙動だった。

- idToken 有: localStorage 既存値を state に積むだけで新規発行しない (stale-id_token + callback regression で Phase A が比較するため既存値は読む必要がある)
- idToken 無: 従来通り `ensureNonce` で発行して Entrance の authorize URL に備える

logout / Phase B 発火時は `rotateNonce` が発行するため、ログイン中に state / storage が空でも次の Entrance 遷移には支障なし。

## Background

PR #103 に follow-up commit として push したつもりが merge 後だったため main に入らず、production で旧挙動が残っていた。本 PR で取り込み直す。

## Test plan

- [x] `bun run check:type` pass
- [x] `bun run check:lint` pass
- [x] `bun test src/TwitchAuth/provider.test.tsx` — 11 pass (38 expect)
  - "returning visitor" テストに `expect(localStorage.getItem("oauth_nonce")).toBeNull()` の assertion を追加済
- [ ] production で login → 別画面 → reload して DevTools Application → Local Storage に `oauth_nonce` が無いこと (手動で削除した後の reload でも再発行されないこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)