### PR TITLE
ci: remove post-merge VRT workaround

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.expected-sha }}
 
-      - name: Use current VRT harness
-        run: |
-          git fetch --depth=1 origin ${{ needs.prepare.outputs.actual-sha }}
-          git checkout ${{ needs.prepare.outputs.actual-sha }} -- client/src/index.css e2e/helpers/waitForCSS.ts
-
       - name: Setup Bun
         run: npm install -g bun@1.3.11
 
@@ -54,7 +49,7 @@ jobs:
       - uses: yorifuji/easy-vrt/expected@v2
         with:
           expected-dir: e2e/__snapshots__/
-          expected-cache-key: ${{ needs.prepare.outputs.expected-sha }}-${{ github.run_id }}
+          expected-cache-key: ${{ needs.prepare.outputs.expected-sha }}
 
   actual:
     if: ${{ !cancelled() && !failure() }}
@@ -85,7 +80,7 @@ jobs:
       - uses: yorifuji/easy-vrt/actual@v2
         with:
           actual-dir: e2e/__snapshots__/
-          actual-cache-key: ${{ needs.prepare.outputs.actual-sha }}-${{ github.run_id }}
+          actual-cache-key: ${{ needs.prepare.outputs.actual-sha }}
 
   compare:
     if: ${{ !cancelled() && !failure() }}
@@ -94,7 +89,7 @@ jobs:
     steps:
       - uses: yorifuji/easy-vrt/compare@v2
         with:
-          expected-cache-key: ${{ needs.prepare.outputs.expected-sha }}-${{ github.run_id }}
-          actual-cache-key: ${{ needs.prepare.outputs.actual-sha }}-${{ github.run_id }}
+          expected-cache-key: ${{ needs.prepare.outputs.expected-sha }}
+          actual-cache-key: ${{ needs.prepare.outputs.actual-sha }}
           summary-comment: true
           review-comment: true


### PR DESCRIPTION
## Summary
- remove the temporary expected-side checkout of the PR VRT harness
- restore easy-vrt cache keys to commit SHA based keys now that main contains the Tailwind source fix

## Notes
- This keeps the stricter CSS wait guard and visual.spec.ts-only screenshot generation, which are still useful for reliable VRT.