### PR TITLE
test: cover remote sync dirty state

### DIFF
--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -129,6 +129,12 @@ test.describe("Template sync", () => {
     await inventoryScreen
       .getTemplateCardScreen(0)
       .state.expectTitleValue("Remote Updated Title");
+    await inventoryScreen
+      .getTemplateCardScreen(0)
+      .state.expectSaveButtonHidden();
+    await inventoryScreen
+      .getTemplateCardScreen(0)
+      .state.expectRevertButtonHidden();
   });
 
   test("keeps offline edits locally and syncs them after reconnect", async ({


### PR DESCRIPTION
## Summary
- add regression assertions for issue #107
- verify that a remote template update updates the local card without showing Save/Revert dirty actions

## Verification
- cd e2e && bunx playwright test sync.spec.ts -g "pulls remote updates" --project=chromium
- cd e2e && bunx playwright test sync.spec.ts --project=chromium
- bun run --filter '@twitch-tag-inventory/e2e' check:lint
- bun run --filter '@twitch-tag-inventory/e2e' check:type

## Notes
Current main does not reproduce #107. This PR keeps the behavior covered so a future change to TemplateCard draft synchronization will fail E2E if it regresses.