### PR TITLE
fix: pin shell-quote to >=1.8.4 (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
     "@embedded-postgres/linux-ppc64": "18.3.0-beta.17",
     "@embedded-postgres/linux-x64": "18.3.0-beta.17",
     "@embedded-postgres/windows-x64": "18.3.0-beta.17",
+    "shell-quote": ">=1.8.4",
     "ws": "8.21.0",
   },
   "packages": {
@@ -566,7 +567,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@embedded-postgres/linux-ppc64": "18.3.0-beta.17",
     "@embedded-postgres/linux-x64": "18.3.0-beta.17",
     "@embedded-postgres/windows-x64": "18.3.0-beta.17",
-    "ws": "8.21.0"
+    "ws": "8.21.0",
+    "shell-quote": ">=1.8.4"
   }
 }


### PR DESCRIPTION
## Summary

- `npm-run-all2` の推移的依存として `shell-quote <=1.8.3` が引き込まれていた
- [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p): `shell-quote` の `quote()` がオブジェクト `.op` 値の改行文字をエスケープしない問題（critical）
- ルートの `overrides` に `"shell-quote": ">=1.8.4"` を追加して修正バージョンに固定

## Test plan

- [x] `bun audit` で脆弱性が検出されないことを確認（ローカルで確認済み）
- [ ] CI (security check) が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)