### PR TITLE
fix(deps): resolve Hono security audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
       "dependencies": {
         "@hono/trpc-server": "^0.4.2",
         "@trpc/server": "^11.17.0",
-        "hono": "^4.12.21",
+        "hono": "^4.12.30",
         "jose": "^6",
         "pg": "^8.20.0",
         "yjs": "^13.6.30",
@@ -403,7 +403,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@hono/trpc-server": "^0.4.2",
     "@trpc/server": "^11.17.0",
-    "hono": "^4.12.21",
+    "hono": "^4.12.30",
     "jose": "^6",
     "pg": "^8.20.0",
     "yjs": "^13.6.30",


### PR DESCRIPTION
## Summary

- update Hono from 4.12.21 to 4.12.30
- refresh the Bun lockfile
- clear the five Hono advisories that currently fail main CI

## Validation

- bun install --frozen-lockfile
- bun run check:type
- bun run check:lint
- bun run check:test (isolated HOME for embedded PostgreSQL)
- bun run build
- bun audit